### PR TITLE
Add minio bootstrap script

### DIFF
--- a/extra/dominode-extra/README.rst
+++ b/extra/dominode-extra/README.rst
@@ -12,14 +12,38 @@ These use `poetry`_, so clone this project, install poetry and then::
     poetry install
 
 
+=====
+Usage
+=====
+
+This package installs the `dominode-admin` CLI tool. Use it like this::
+
+    poetry run dominode-admin --help
+
+
++++++++++++++++++++++++++++++++++++++
+Bootstrapping DomiNode infrastructure
++++++++++++++++++++++++++++++++++++++
+
+In order to bootstrap the DomiNode infrastructure either::
+
+    poetry run dominode-admin bootstrap
+
+
+Or bootstrap each resource individually::
+
+    poetry run dominode-admin db bootstrap
+    poetry run dominode-admin minio bootstrap
+
+
 
 =============
 Running tests
 =============
 
-This uses `pytest`_, so to run tests::
+This package uses `pytest`_, so to run tests::
 
-    poetry run pytest -v -x
+    poetry run pytest
 
 .. _poetry: https://python-poetry.org/
 .. _pytest: https://docs.pytest.org/en/latest/

--- a/extra/dominode-extra/dominode_extra/constants.py
+++ b/extra/dominode-extra/dominode_extra/constants.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class DepartmentName(Enum):
+    PPD = 'ppd'
+    LSD = 'lsd'
+
+
+class UserRole(str, Enum):
+    REGULAR_DEPARTMENT_USER = 'regular_department_user'
+    EDITOR = 'editor'

--- a/extra/dominode-extra/dominode_extra/dbadmin.py
+++ b/extra/dominode-extra/dominode_extra/dbadmin.py
@@ -1,0 +1,115 @@
+"""Extra admin commands to manage the DomiNode database server
+
+This script adds some functions to perform DomiNode related tasks in a more
+expedite manner than using the bare `psql` client
+
+"""
+
+import typing
+from configparser import ConfigParser
+from contextlib import contextmanager
+from pathlib import Path
+from time import sleep
+
+import sqlalchemy as sla
+import typer
+from sqlalchemy.exc import OperationalError
+
+from .constants import (
+    DepartmentName,
+    UserRole,
+)
+
+_help_intro = 'Manage postgis database'
+
+app = typer.Typer(
+    short_help=_help_intro,
+    help=_help_intro
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_CONFIG_DIR = Path('~/.pg_service.conf').expanduser()
+
+
+@app.command()
+def bootstrap(
+        db_service_name: str,
+        db_service_file: Path = DEFAULT_CONFIG_DIR
+):
+    """Perform initial bootstrap of the database
+
+    This function will take care of creating the relevant schemas, group roles
+    and access controls for using the postgis database for DomiNode.
+
+    """
+    db_url = load_postgres_service(db_service_name, db_service_file.read_text())
+    bootstrap_sql_path = REPO_ROOT / 'sql/bootstrap-db.sql'
+    with get_db_connection(db_url) as db_connection:
+        raw_connection = db_connection.connection
+        raw_cursor = raw_connection.cursor()
+        typer.echo('Bootstrapping db...')
+        raw_cursor.execute(bootstrap_sql_path.read_text())
+        raw_connection.commit()
+
+
+@app.command()
+def add_department_user(
+        db_service_name: str,
+        username: str,
+        password: str,
+        department: DepartmentName,
+        role: typing.Optional[UserRole] = UserRole.REGULAR_DEPARTMENT_USER,
+        db_service_file: Path = DEFAULT_CONFIG_DIR
+):
+    db_url = load_postgres_service(db_service_name, db_service_file.read_text())
+    sql_role = {
+        UserRole.EDITOR: f'{department.value}_editor',
+        UserRole.REGULAR_DEPARTMENT_USER: f'{department.value}_user',
+    }[role]
+    with get_db_connection(db_url) as db_connection:
+        raw_connection = db_connection.connection
+        raw_cursor = raw_connection.cursor()
+        typer.echo(f'Creating user {username}...')
+        raw_cursor.execute(
+            f'CREATE USER {username} PASSWORD \'{password}\' IN ROLE {sql_role}'
+        )
+        raw_connection.commit()
+
+
+@contextmanager
+def get_db_connection(db_url: str):
+    engine = sla.create_engine(db_url)
+    connected = False
+    max_tries = 30
+    current_try = 0
+    sleep_for = 2  # seconds
+    while not connected and current_try < max_tries:
+        try:
+            with engine.connect() as connection:
+                connected = True
+                yield connection
+        except OperationalError:
+            print(f'Could not connect to DB ({current_try + 1}/{max_tries})')
+            current_try += 1
+            if current_try < max_tries:
+                sleep(sleep_for)
+            else:
+                raise
+
+
+def load_postgres_service(
+        service:str,
+        service_file_contents: str
+) -> str:
+    config = ConfigParser()
+    config.read_string(service_file_contents)
+    section = config[service]
+    return (
+        f'postgresql://{section["user"]}:{section["password"]}@'
+        f'{section["host"]}:{section.get("port", 5432)}/'
+        f'{section["dbname"]}'
+    )
+
+
+def parse_postgres_service(service: typing.MutableMapping) -> str:
+    pass

--- a/extra/dominode-extra/dominode_extra/dominodeadmin.py
+++ b/extra/dominode-extra/dominode_extra/dominodeadmin.py
@@ -1,0 +1,22 @@
+"""Extra commands to manage the DomiNode system"""
+
+import typer
+from pathlib import Path
+
+from . import minioadmin
+from . import dbadmin
+
+app = typer.Typer()
+app.add_typer(minioadmin.app, name='minio')
+app.add_typer(dbadmin.app, name='db')
+
+
+@app.command()
+def bootstrap(
+        db_service_name: str,
+        minio_endpoint_alias: str,
+        db_service_fle: Path = dbadmin.DEFAULT_CONFIG_DIR,
+        minio_client_config_dir: Path = minioadmin.DEFAULT_CONFIG_DIR,
+):
+    dbadmin.bootstrap(db_service_name, db_service_fle)
+    minioadmin.bootstrap(minio_endpoint_alias, minio_client_config_dir)

--- a/extra/dominode-extra/dominode_extra/minioadmin.py
+++ b/extra/dominode-extra/dominode_extra/minioadmin.py
@@ -296,7 +296,7 @@ def add_department(
 
     department = DomiNodeDepartment(
         name, endpoint_alias, minio_client_config_dir)
-    typer.echo(f'department config_dir: {department.minio_client_config_dir}')
+    # typer.echo(f'department config_dir: {department.minio_client_config_dir}')
     department.create_groups()
     department.create_buckets()
     department.create_policies()
@@ -308,8 +308,8 @@ def bootstrap_server(
         endpoint_alias: str,
         minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
 ):
-    typer.echo(f'locals: {locals()}')
-    typer.echo(f'config.json: {(minio_client_config_dir / "config.json").read_text()}')
+    # typer.echo(f'locals: {locals()}')
+    # typer.echo(f'config.json: {(minio_client_config_dir / "config.json").read_text()}')
     # groups cannot be nested
     for member in DepartmentName:
         add_department(endpoint_alias, member, minio_client_config_dir)
@@ -441,9 +441,8 @@ def execute_command(
         minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
 ):
     full_command = (
-        f'mc {command} {"/".join((endpoint_alias, arguments or ""))} '
-        f'--json '
-        f'--config-dir {minio_client_config_dir}'
+        f'mc --config-dir {minio_client_config_dir} --json {command} '
+        f'{"/".join((endpoint_alias, arguments or ""))}'
     )
     typer.echo(full_command)
     parsed_command = shlex.split(full_command)
@@ -467,13 +466,16 @@ def execute_admin_command(
         minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
 ) -> typing.List:
     """Uses the ``mc`` binary to perform admin tasks on minIO servers"""
-    typer.echo(f'inside execute_admin_command')
-    typer.echo(f'endpoint_alias: {endpoint_alias}')
-    typer.echo(f'minio_client_config_dir: {minio_client_config_dir}')
-    typer.echo(f'contents of config.json: {(minio_client_config_dir / "config.json").read_text()}')
+    # typer.echo(f'inside execute_admin_command')
+    # typer.echo(f'endpoint_alias: {endpoint_alias}')
+    # typer.echo(f'minio_client_config_dir: {minio_client_config_dir}')
+    # typer.echo(f'contents of config.json: {(minio_client_config_dir / "config.json").read_text()}')
     full_command = (
-        f'mc admin {command} {endpoint_alias} {arguments or ""} --json')
-    full_command = full_command + f' --config-dir {minio_client_config_dir}'
+        f'mc --config-dir {minio_client_config_dir} --json admin {command} '
+        f'{endpoint_alias} {arguments or ""}'
+    )
+
+
     parsed_command = shlex.split(full_command)
     completed = subprocess.run(
         parsed_command,

--- a/extra/dominode-extra/dominode_extra/minioadmin.py
+++ b/extra/dominode-extra/dominode_extra/minioadmin.py
@@ -45,11 +45,11 @@ class DomiNodeDepartment:
 
     @property
     def staging_bucket(self) -> str:
-        return f'{self.name}_staging'
+        return f'{self.name}-staging'
 
     @property
     def production_bucket(self) -> str:
-        return f'{self.name}_public'
+        return f'{self.name}-public'
 
     @property
     def regular_users_group(self) -> str:
@@ -193,10 +193,14 @@ def add_department(
         endpoint_alias,
         f'{department.name}_staging_bucket_policy',
         department.dominode_staging_bucket_policy,
+        minio_client_config_dir
+    )
+    set_policy(
+        endpoint_alias,
+        f'{department.name}_staging_bucket_policy',
         department.regular_users_group,
         minio_client_config_dir
     )
-    # set_policy()
     create_group(
         endpoint_alias, department.editors_group, minio_client_config_dir)
 
@@ -217,9 +221,9 @@ def add_policy(
         endpoint_alias: str,
         name: str,
         policy: typing.Dict,
-        group: str,
         minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
 ):
+    """Add policy to the server"""
     existing_policies = execute_admin_command(endpoint_alias, 'policy list')
     for item in existing_policies:
         if item.get('policy') == name:
@@ -235,6 +239,20 @@ def add_policy(
             minio_client_config_dir=minio_client_config_dir
         )
         Path(pathname).unlink(missing_ok=True)
+
+
+def set_policy(
+        endpoint_alias: str,
+        policy: str,
+        group: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    command_result = execute_admin_command(
+        endpoint_alias,
+        'policy set',
+        f'{policy} group={group}',
+        minio_client_config_dir=minio_client_config_dir
+    )
 
 
 @app.command()

--- a/extra/dominode-extra/dominode_extra/minioadmin.py
+++ b/extra/dominode-extra/dominode_extra/minioadmin.py
@@ -296,6 +296,7 @@ def add_department(
 
     department = DomiNodeDepartment(
         name, endpoint_alias, minio_client_config_dir)
+    typer.echo(f'department config_dir: {department.minio_client_config_dir}')
     department.create_groups()
     department.create_buckets()
     department.create_policies()
@@ -307,6 +308,8 @@ def bootstrap_server(
         endpoint_alias: str,
         minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
 ):
+    typer.echo(f'locals: {locals()}')
+    typer.echo(f'config.json: {(minio_client_config_dir / "config.json").read_text()}')
     # groups cannot be nested
     for member in DepartmentName:
         add_department(endpoint_alias, member, minio_client_config_dir)
@@ -464,6 +467,10 @@ def execute_admin_command(
         minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
 ) -> typing.List:
     """Uses the ``mc`` binary to perform admin tasks on minIO servers"""
+    typer.echo(f'inside execute_admin_command')
+    typer.echo(f'endpoint_alias: {endpoint_alias}')
+    typer.echo(f'minio_client_config_dir: {minio_client_config_dir}')
+    typer.echo(f'contents of config.json: {(minio_client_config_dir / "config.json").read_text()}')
     full_command = (
         f'mc admin {command} {endpoint_alias} {arguments or ""} --json')
     full_command = full_command + f' --config-dir {minio_client_config_dir}'

--- a/extra/dominode-extra/dominode_extra/minioadmin.py
+++ b/extra/dominode-extra/dominode_extra/minioadmin.py
@@ -1,0 +1,411 @@
+"""Commands to bootstrap minIO server
+
+- Create buckets
+- Create groups
+- Create policies
+- Apply policies
+
+
+Early example usage:
+poetry run python dominode_extra/minioadmin.py add-department dominode-dev ppd
+poetry run python dominode_extra/minioadmin.py add-user dominode-dev ppd user1 12345678
+
+"""
+
+import json
+import shlex
+import subprocess
+import tempfile
+import typing
+from contextlib import contextmanager
+from pathlib import Path
+from os import fdopen
+
+import typer
+from enum import Enum
+from minio import Minio
+
+app = typer.Typer()
+
+SUCCESS = "success"
+DEFAULT_CONFIG_DIR = Path('~/.mc').expanduser()
+
+
+class DepartmentName(Enum):
+    PPD = 'ppd'
+    LSD = 'lsd'
+
+
+class DomiNodeDepartment:
+    name: str
+    _policy_version: str = '2012-10-17'
+
+    def __init__(self, name: DepartmentName):
+        self.name = name.value
+
+    @property
+    def staging_bucket(self) -> str:
+        return f'{self.name}_staging'
+
+    @property
+    def production_bucket(self) -> str:
+        return f'{self.name}_public'
+
+    @property
+    def regular_users_group(self) -> str:
+        return f'{self.name}_user'
+
+    @property
+    def editors_group(self) -> str:
+        return f'{self.name}_editor'
+
+    @property
+    def dominode_staging_root_dir(self) -> str:
+        return f'dominode_staging/{self.name}'
+
+    @property
+    def staging_bucket_policy(self) -> typing.Dict:
+        return {
+            'Version': self._policy_version,
+            'Statement': [
+                {
+                    'Sid': '',
+                    'Action': [
+                        's3:*'
+                    ],
+                    'Effect': 'Allow',
+                    'Resource': [
+                        f'arn:aws:s3:::{self.staging_bucket}/*'
+                    ]
+                }
+            ]
+        }
+
+    @property
+    def dominode_staging_bucket_policy(self) -> typing.Dict:
+        return {
+            'Version': self._policy_version,
+            'Statement': [
+                {
+                    'Sid': '',
+                    'Action': [
+                        's3:*'
+                    ],
+                    'Effect': 'Allow',
+                    'Resource': [
+                        f'arn:aws:s3:::{self.dominode_staging_root_dir}/*'
+                    ]
+                }
+            ]
+        }
+
+    @property
+    def dominode_production_bucket_policy_regular_user(self) -> typing.Dict:
+        return {
+            'Version': self._policy_version,
+            'Statement': [
+                {
+                    'Sid': '',
+                    'Action': [
+                        's3:GetBucketLocation',
+                        's3:GetObject'
+                    ],
+                    'Effect': 'Allow',
+                    'Resource': [
+                        f'arn:aws:s3:::{self.dominode_staging_root_dir}/*'
+                    ]
+                }
+            ]
+        }
+
+    @property
+    def dominode_production_bucket_policy_editor_user(self) -> typing.Dict:
+        return {
+            'Version': self._policy_version,
+            'Statement': [
+                {
+                    'Sid': '',
+                    'Action': [
+                        's3:GetBucketLocation',
+                        's3:GetObject',
+                        # TODO: add more actions
+                        # - creating directories
+                        # - copying objects from owned buckets
+                        # - deleting objects objects
+                        # - etc
+                    ],
+                    'Effect': 'Allow',
+                    'Resource': [
+                        f'arn:aws:s3:::{self.dominode_staging_root_dir}/*'
+                    ]
+                }
+            ]
+        }
+
+
+@app.command()
+def add_user(
+        endpoint_alias: str,
+        department_name: DepartmentName,
+        access_key: str,
+        secret_key: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    create_user(
+        endpoint_alias,
+        access_key,
+        secret_key,
+        minio_client_config_dir=minio_client_config_dir
+    )
+    department = DomiNodeDepartment(department_name)
+    addition_result = execute_admin_command(
+        endpoint_alias,
+        'group add', f'{department.name} {access_key}',
+        minio_client_config_dir=minio_client_config_dir
+    )
+    return addition_result[0].get('status') == SUCCESS
+
+
+
+@app.command()
+def add_department(
+        endpoint_alias: str,
+        name: DepartmentName,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    """Add a new department
+
+    This includes:
+
+    -  Adding department staging bucket
+    -  Adding department groups
+
+    """
+
+    department = DomiNodeDepartment(name)
+
+    # create groups
+    # assign policies
+    # create buckets/dirs
+    create_group(
+        endpoint_alias, department.regular_users_group, minio_client_config_dir)
+    add_policy(
+        endpoint_alias,
+        f'{department.name}_staging_bucket_policy',
+        department.dominode_staging_bucket_policy,
+        department.regular_users_group,
+        minio_client_config_dir
+    )
+    # set_policy()
+    create_group(
+        endpoint_alias, department.editors_group, minio_client_config_dir)
+
+
+@app.command()
+def remove_department(
+        endpoint_alias: str,
+        name: DepartmentName,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    department = DomiNodeDepartment(name)
+    remove_group(endpoint_alias, department.editors_group, DEFAULT_CONFIG_DIR)
+    remove_group(
+        endpoint_alias, department.regular_users_group, DEFAULT_CONFIG_DIR)
+
+
+def add_policy(
+        endpoint_alias: str,
+        name: str,
+        policy: typing.Dict,
+        group: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    existing_policies = execute_admin_command(endpoint_alias, 'policy list')
+    for item in existing_policies:
+        if item.get('policy') == name:
+            break  # policy already exists
+    else:
+        os_file_handler, pathname = tempfile.mkstemp(text=True)
+        with fdopen(os_file_handler, mode='w') as fh:
+            json.dump(policy, fh)
+        creation_result = execute_admin_command(
+            endpoint_alias,
+            'policy add',
+            f'{name} {pathname}',
+            minio_client_config_dir=minio_client_config_dir
+        )
+        Path(pathname).unlink(missing_ok=True)
+
+
+@app.command()
+def bootstrap_minio_server(
+        endpoint_alias: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    parent_groups = [
+        'dominode_user',
+        'editor',
+    ]
+    for department in DepartmentName:
+        add_department(endpoint_alias, department, minio_client_config_dir)
+
+
+def create_group(
+        endpoint_alias: str,
+        group: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+) -> typing.Optional[str]:
+    existing_groups = execute_admin_command(
+        endpoint_alias,
+        'group list',
+        minio_client_config_dir=minio_client_config_dir
+    )
+    for existing in existing_groups:
+        if existing.get('name') == group:
+            result = group
+            break
+    else:
+        # minio does not allow creating empty groups so we need a user first
+        with get_temp_user(endpoint_alias, minio_client_config_dir) as user:
+            temp_access_key = user[0]
+            creation_result = execute_admin_command(
+                endpoint_alias,
+                'group add',
+                f'{group} {temp_access_key}',
+                minio_client_config_dir=minio_client_config_dir
+            )
+            relevant_result = creation_result[0]
+            if relevant_result.get('status') == SUCCESS:
+                result = group
+            else:
+                result = None
+    return result
+
+
+def remove_group(
+        endpoint_alias: str,
+        group: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    removal_result = execute_admin_command(
+        endpoint_alias, 'group remove', group, minio_client_config_dir)
+    return removal_result[0].get('status') == SUCCESS
+
+
+def create_temp_user(
+        endpoint_alias: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+) -> typing.Optional[typing.Tuple[str, str]]:
+    access_key = 'tempuser'
+    secret_key = '12345678'
+    created = create_user(
+        endpoint_alias,
+        access_key,
+        secret_key,
+        force=True,
+        minio_client_config_dir=minio_client_config_dir
+    )
+    if created:
+        result = access_key, secret_key
+    else:
+        result = None
+    return result
+
+
+@contextmanager
+def get_temp_user(
+        endpoint_alias: str,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+):
+    user_creds = create_temp_user(endpoint_alias, minio_client_config_dir)
+    if user_creds is not None:
+        access_key, secret_key = user_creds
+        try:
+            yield user_creds
+        finally:
+            execute_admin_command(
+                endpoint_alias,
+                'user remove',
+                access_key,
+                minio_client_config_dir=minio_client_config_dir
+            )
+
+
+def create_user(
+        endpoint_alias: str,
+        access_key: str,
+        secret_key: str,
+        force: bool = False,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+) -> bool:
+    # minio allows overwriting users with the same access_key, so we check if
+    # user exists first
+    existing_users = execute_admin_command(
+        endpoint_alias,
+        'user list',
+        minio_client_config_dir=minio_client_config_dir
+    )
+    if len(secret_key) < 8:
+        raise RuntimeError(
+            'Please choose a secret key with 8 or more characters')
+    for existing in existing_users:
+        if existing.get('accessKey') == access_key:
+            user_already_exists = True
+            break
+    else:
+        user_already_exists = False
+    if not user_already_exists or (user_already_exists and force):
+        creation_result = execute_admin_command(
+            endpoint_alias,
+            'user add',
+            f'{access_key} {secret_key}',
+            minio_client_config_dir=minio_client_config_dir
+        )
+        result = creation_result[0].get('status') == SUCCESS
+    elif user_already_exists:  # TODO: should log that user was not recreated
+        result = True
+    else:
+        result = False
+    return result
+
+
+def get_client(
+        endpoint: str,
+        access_key: str,
+        secret_key: str,
+        secure: bool = False
+) -> Minio:
+    return Minio(
+        endpoint,
+        access_key=access_key,
+        secret_key=secret_key,
+        secure=secure
+    )
+
+
+def execute_admin_command(
+        endpoint_alias: str,
+        command: str,
+        arguments: typing.Optional[str] = None,
+        minio_client_config_dir: typing.Optional[Path] = DEFAULT_CONFIG_DIR
+) -> typing.List:
+    """Uses the ``mc`` binary to perform admin tasks on minIO servers"""
+    full_command = (
+        f'mc admin {command} {endpoint_alias} {arguments or ""} --json')
+    full_command = full_command + f' --config-dir {minio_client_config_dir}'
+    parsed_command = shlex.split(full_command)
+    completed = subprocess.run(
+        parsed_command,
+        capture_output=True
+    )
+    try:
+        completed.check_returncode()
+    except subprocess.CalledProcessError:
+        typer.echo(completed.stdout)
+        raise
+    result = [json.loads(line) for line in completed.stdout.splitlines()]
+    return result
+
+
+if __name__ == '__main__':
+    app()

--- a/extra/dominode-extra/dominode_extra/minioadmin.py
+++ b/extra/dominode-extra/dominode_extra/minioadmin.py
@@ -87,6 +87,17 @@ class DomiNodeDepartment:
                 'Version': self._policy_version,
                 'Statement': [
                     {
+                        'Sid': f'{self.name}-regular-user-deny-bucket-delete',
+                        'Action': [
+                            's3:DeleteBucket',
+                        ],
+                        'Effect': 'Deny',
+                        'Resource': [
+                            f'arn:aws:s3:::{self.dominode_staging_bucket}',
+                            f'arn:aws:s3:::{self.staging_bucket}',
+                        ]
+                    },
+                    {
                         'Sid': f'{self.name}-regular-user-full-access',
                         'Action': [
                             's3:*'
@@ -106,7 +117,8 @@ class DomiNodeDepartment:
                         ],
                         'Effect': 'Allow',
                         'Resource': [
-                            f'arn:aws:s3:::{self.dominode_staging_bucket}/*'
+                            f'arn:aws:s3:::{self.dominode_staging_bucket}/*',
+                            f'arn:aws:s3:::{self.public_bucket}/*'
                         ]
                     },
                 ]
@@ -120,6 +132,17 @@ class DomiNodeDepartment:
             {
                 'Version': self._policy_version,
                 'Statement': [
+                    {
+                        'Sid': f'{self.name}-editor-user-deny-bucket-delete',
+                        'Action': [
+                            's3:DeleteBucket',
+                        ],
+                        'Effect': 'Deny',
+                        'Resource': [
+                            f'arn:aws:s3:::{self.dominode_staging_bucket}',
+                            f'arn:aws:s3:::{self.staging_bucket}',
+                        ]
+                    },
                     {
                         'Sid': f'{self.name}-editor-full-access',
                         'Action': [

--- a/extra/dominode-extra/poetry.lock
+++ b/extra/dominode-extra/poetry.lock
@@ -55,6 +55,14 @@ python-versions = "*"
 version = "3.0.4"
 
 [[package]]
+category = "main"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
+
+[[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
@@ -435,6 +443,23 @@ six = "*"
 test = ["pytest", "mock"]
 
 [[package]]
+category = "main"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+name = "typer"
+optional = false
+python-versions = ">=3.6"
+version = "0.3.0"
+
+[package.dependencies]
+click = ">=7.1.1,<7.2.0"
+
+[package.extras]
+all = ["colorama", "shellingham"]
+dev = ["autoflake", "flake8"]
+doc = ["mkdocs", "mkdocs-material", "markdown-include"]
+test = ["shellingham", "pytest (>=4.4.0,<5.4)", "pytest-cov", "coverage", "pytest-xdist", "pytest-sugar", "mypy", "black", "isort"]
+
+[[package]]
 category = "dev"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
@@ -467,7 +492,7 @@ version = "0.57.0"
 six = "*"
 
 [metadata]
-content-hash = "f5e7683af10e91d841926c3a4e058cfdf62caa38ad2c63227f3e247cb07c3a69"
+content-hash = "0009e610db238f4b702a21644fa9fe8775b97936bddf2c0b2635b48d5a4d7378"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -494,6 +519,10 @@ certifi = [
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
@@ -683,6 +712,10 @@ sqlalchemy = [
 traitlets = [
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
     {file = "traitlets-4.3.3.tar.gz", hash = "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"},
+]
+typer = [
+    {file = "typer-0.3.0-py3-none-any.whl", hash = "sha256:a2a7b4b6388debc2b7160c8b7a54368df85b56c3f1447846bad630e99d629ffc"},
+    {file = "typer-0.3.0.tar.gz", hash = "sha256:f025d6bbb2fcefaf861dec5a006e9b5128532f733b7f75b57b1fd803bed31cdd"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},

--- a/extra/dominode-extra/poetry.lock
+++ b/extra/dominode-extra/poetry.lock
@@ -65,6 +65,18 @@ version = "0.4.3"
 
 [[package]]
 category = "dev"
+description = "Updated configparser from Python 3.8 for Python 2.6+."
+name = "configparser"
+optional = false
+python-versions = ">=3.6"
+version = "5.0.0"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
+
+[[package]]
+category = "dev"
 description = "Decorators for Humans"
 name = "decorator"
 optional = false
@@ -154,6 +166,21 @@ parso = ">=0.7.0,<0.8.0"
 [package.extras]
 qa = ["flake8 (3.7.9)"]
 testing = ["Django (<3.1)", "colorama", "docopt", "pytest (>=3.9.0,<5.0.0)"]
+
+[[package]]
+category = "dev"
+description = "MinIO Python Library for Amazon S3 Compatible Cloud Storage for Python"
+name = "minio"
+optional = false
+python-versions = "*"
+version = "5.0.10"
+
+[package.dependencies]
+certifi = "*"
+configparser = "*"
+python-dateutil = "*"
+pytz = "*"
+urllib3 = "*"
 
 [[package]]
 category = "dev"
@@ -319,6 +346,25 @@ develop = ["pylint", "pytest-cov"]
 
 [[package]]
 category = "dev"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+version = "2.8.1"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "dev"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2020.1"
+
+[[package]]
+category = "dev"
 description = "Python for Window Extensions"
 marker = "sys_platform == \"win32\" and python_version >= \"3.6\""
 name = "pywin32"
@@ -421,7 +467,7 @@ version = "0.57.0"
 six = "*"
 
 [metadata]
-content-hash = "f1e03af9763bce10bac4d844ef23241fb8ddc2da45e1044e51d94c15e5554904"
+content-hash = "f5e7683af10e91d841926c3a4e058cfdf62caa38ad2c63227f3e247cb07c3a69"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -453,6 +499,10 @@ colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
+configparser = [
+    {file = "configparser-5.0.0-py3-none-any.whl", hash = "sha256:cffc044844040c7ce04e9acd1838b5f2e5fa3170182f6fda4d2ea8b0099dbadd"},
+    {file = "configparser-5.0.0.tar.gz", hash = "sha256:2ca44140ee259b5e3d8aaf47c79c36a7ab0d5e94d70bd4105c03ede7a20ea5a1"},
+]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
     {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
@@ -476,6 +526,11 @@ ipython-genutils = [
 jedi = [
     {file = "jedi-0.17.1-py2.py3-none-any.whl", hash = "sha256:1ddb0ec78059e8e27ec9eb5098360b4ea0a3dd840bedf21415ea820c21b40a22"},
     {file = "jedi-0.17.1.tar.gz", hash = "sha256:807d5d4f96711a2bcfdd5dfa3b1ae6d09aa53832b182090b222b5efb81f52f63"},
+]
+minio = [
+    {file = "minio-5.0.10-py2.py3-none-any.whl", hash = "sha256:ba5978a97e3366983c8b4ea11f2ae8e1add995ab4789e0098dd2403199999ac4"},
+    {file = "minio-5.0.10-py3.6.egg", hash = "sha256:71984a47fc8268afdfd1d0ed5e45e72f45f6495591878b0eaa7f77b2503e96ab"},
+    {file = "minio-5.0.10.tar.gz", hash = "sha256:6ecb7637a35f806733e9d112eacfa599a58d7c3d4698fda2b5c86fff5d34b417"},
 ]
 more-itertools = [
     {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
@@ -564,6 +619,14 @@ pytest = [
 pytest-raises = [
     {file = "pytest-raises-0.11.tar.gz", hash = "sha256:f64a4dbcb5f89c100670fe83d87a5cd9d956586db461c5c628f7eb94b749c90b"},
     {file = "pytest_raises-0.11-py2.py3-none-any.whl", hash = "sha256:33a1351f2debb9f74ca6ef70e374899f608a1217bf13ca4a0767f37b49e9cdda"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+pytz = [
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 pywin32 = [
     {file = "pywin32-228-cp27-cp27m-win32.whl", hash = "sha256:37dc9935f6a383cc744315ae0c2882ba1768d9b06700a70f35dc1ce73cd4ba9c"},

--- a/extra/dominode-extra/pyproject.toml
+++ b/extra/dominode-extra/pyproject.toml
@@ -20,3 +20,6 @@ minio = "^5.0.10"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+[tool.poetry.scripts]
+minioadmin = 'dominode_extra.minioadmin:app'

--- a/extra/dominode-extra/pyproject.toml
+++ b/extra/dominode-extra/pyproject.toml
@@ -22,4 +22,4 @@ requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
 [tool.poetry.scripts]
-minioadmin = 'dominode_extra.minioadmin:app'
+dominode-admin = 'dominode_extra.dominodeadmin:app'

--- a/extra/dominode-extra/pyproject.toml
+++ b/extra/dominode-extra/pyproject.toml
@@ -14,6 +14,7 @@ psycopg2-binary = "^2.8.5"
 sqlalchemy = "^1.3.18"
 ipython = "^7.16.1"
 pytest-raises = "^0.11"
+minio = "^5.0.10"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/extra/dominode-extra/pyproject.toml
+++ b/extra/dominode-extra/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
+typer = "^0.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/extra/dominode-extra/tests/conftest.py
+++ b/extra/dominode-extra/tests/conftest.py
@@ -192,6 +192,18 @@ def minio_client(minio_server, minio_server_info):
     return client
 
 
+@pytest.fixture()
+def minio_admin_client(minio_server, minio_server_info):
+    endpoint = f'localhost:{minio_server_info["port"]}'
+    client = Minio(
+        endpoint=endpoint,
+        access_key=minio_server_info['access_key'],
+        secret_key=minio_server_info['secret_key'],
+        secure=False,
+    )
+    return client
+
+
 @pytest.fixture(scope='session')
 def minio_users_credentials():
     return {

--- a/extra/dominode-extra/tests/conftest.py
+++ b/extra/dominode-extra/tests/conftest.py
@@ -134,7 +134,7 @@ def minio_server(docker_client, minio_server_info):
         detach=True,
         command='server /data',
         name='minio-server-pytest',
-        auto_remove=True,
+        #auto_remove=True,
         ports={
             9000: minio_server_info['port']
         },
@@ -145,7 +145,7 @@ def minio_server(docker_client, minio_server_info):
     )
     yield container
     logger.info(f'Removing container...')
-    container.stop()
+    #container.stop()
 
 
 @pytest.fixture(scope='session')
@@ -223,9 +223,9 @@ def bootstrapped_minio_server(
             'hosts': {
                 server_alias: {
                     'url': f'http://localhost:{minio_server_info["port"]}',
-                    'access_key': minio_server_info['access_key'],
-                    'secret_key': minio_server_info['secret_key'],
-                    'api': 's3v4',
+                    'accessKey': minio_server_info['access_key'],
+                    'secretKey': minio_server_info['secret_key'],
+                    'api': 'S3v4',
                     'lookup': 'auto',
                 }
             }
@@ -237,7 +237,8 @@ def bootstrapped_minio_server(
     completed_process = subprocess.run(
         shlex.split(
             f'minioadmin bootstrap-server {server_alias} '
-            f'--minio-client-config-dir={temp_dir}'
+            #f'--minio-client-config-dir={temp_dir}'
+            f'--minio-client-config-dir=/tmp/mytest'
         ),
         capture_output=True
     )

--- a/extra/dominode-extra/tests/conftest.py
+++ b/extra/dominode-extra/tests/conftest.py
@@ -1,10 +1,12 @@
 import logging
 from pathlib import Path
 from time import sleep
+from urllib3.exceptions import MaxRetryError
 
 import docker
 import pytest
 import sqlalchemy as sla
+from minio import Minio
 from sqlalchemy.exc import OperationalError
 
 logger = logging.getLogger(__name__)
@@ -110,3 +112,61 @@ def db_users(bootstrapped_db_connection, db_users_credentials):
         bootstrapped_db_connection.execute(
             f'CREATE USER {user} PASSWORD \'{password}\' IN ROLE {", ".join(roles)}')
     return bootstrapped_db_connection
+
+
+@pytest.fixture(scope='session')
+def minio_server_info():
+    return {
+        'name': 'minio-server-pytest',
+        'host': 'localhost',
+        'port': '9100',
+        'access_key': 'myuser',
+        'secret_key': 'mypassword',
+    }
+
+
+@pytest.fixture(scope='session')
+def minio_server(docker_client, minio_server_info):
+    container = docker_client.containers.run(
+        'minio/minio',
+        detach=True,
+        name=minio_server_info['name'],
+        remove=True,
+        network='host',
+        ports={
+            '9000': minio_server_info['port']
+        },
+        environment={
+            'MINIO_ACCESS_KEY': minio_server_info['access_key'],
+            'MINIO_SECRET_KEY': minio_server_info['secret_key'],
+        }
+
+    )
+    yield container
+    logger.info(f'Removing container...')
+    container.stop()
+
+
+@pytest.fixture(scope='session')
+def minio_client(minio_server, minio_server_info):
+    connected = False
+    max_tries = 30
+    current_try = 0
+    sleep_for = 2  # seconds
+    while not connected and current_try < max_tries:
+        try:
+            client = Minio(
+                f'{minio_server_info["host"]}:{minio_server_info["port"]}',
+                access_key=minio_server_info['access_key'],
+                secret_key=minio_server_info['secret_key'],
+                secure=False
+            )
+            break
+        except MaxRetryError:
+            print(f'Could not connect to minIO server ({current_try + 1}/{max_tries})')
+            current_try += 1
+            if current_try < max_tries:
+                sleep(sleep_for)
+            else:
+                raise
+    return client

--- a/extra/dominode-extra/tests/test_bootstrap_minio.py
+++ b/extra/dominode-extra/tests/test_bootstrap_minio.py
@@ -5,7 +5,8 @@ from minio import Minio
 
 
 @pytest.mark.parametrize('access_key, expected_num_buckets', [
-    pytest.param('ppd_user1', 2)
+    pytest.param('ppd_user1', 2),
+    pytest.param('ppd_editor1', 3),
 ])
 def test_regular_user_has_access_to_buckets(
         minio_server_info,

--- a/extra/dominode-extra/tests/test_bootstrap_minio.py
+++ b/extra/dominode-extra/tests/test_bootstrap_minio.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_minio_server_comes_up(minio_client):
+def test_minio_server_comes_up(minio_client, bootstrapped_minio_server):
     buckets = minio_client.list_buckets()
     print(f'buckets: {buckets}')
     assert len(buckets) > 0

--- a/extra/dominode-extra/tests/test_bootstrap_minio.py
+++ b/extra/dominode-extra/tests/test_bootstrap_minio.py
@@ -14,7 +14,8 @@ def test_regular_user_has_access_to_buckets(
         access_key,
         expected_num_buckets
 ):
-    minio_client = _get_minio_client(access_key, minio_users_credentials, minio_server_info['port'])
+    minio_client = _get_minio_client(
+        access_key, minio_users_credentials, minio_server_info['port'])
     buckets = minio_client.list_buckets()
     print(f'buckets: {buckets}')
     assert len(buckets) == expected_num_buckets

--- a/extra/dominode-extra/tests/test_bootstrap_minio.py
+++ b/extra/dominode-extra/tests/test_bootstrap_minio.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_minio_server_comes_up(minio_client):
+    buckets = minio_client.list_buckets()
+    print(f'buckets: {buckets}')
+    assert len(buckets) > 0

--- a/extra/dominode-extra/tests/test_bootstrap_minio.py
+++ b/extra/dominode-extra/tests/test_bootstrap_minio.py
@@ -1,11 +1,15 @@
+import io
+import os
 import typing
+from urllib3.response import HTTPResponse
 
 import pytest
-from minio import Minio
+import minio
+import minio.error
 
 
 @pytest.mark.parametrize('access_key, expected_num_buckets', [
-    pytest.param('ppd_user1', 2),
+    pytest.param('ppd_user1', 3),
     pytest.param('ppd_editor1', 3),
 ])
 def test_regular_user_has_access_to_buckets(
@@ -16,20 +20,176 @@ def test_regular_user_has_access_to_buckets(
         expected_num_buckets
 ):
     minio_client = _get_minio_client(
-        access_key, minio_users_credentials, minio_server_info['port'])
+        access_key, minio_users_credentials, minio_server_info)
     buckets = minio_client.list_buckets()
     print(f'buckets: {buckets}')
     assert len(buckets) == expected_num_buckets
 
 
+@pytest.mark.parametrize('access_key, bucket', [
+    pytest.param('ppd_user1', 'mybucket', marks=pytest.mark.raises(exception=minio.error.AccessDenied))
+])
+def test_user_cannot_create_new_bucket(
+        bootstrapped_minio_server,
+        minio_users_credentials,
+        minio_server_info,
+        access_key,
+        bucket
+):
+    minio_client = _get_minio_client(
+        access_key, minio_users_credentials, minio_server_info
+    )
+    minio_client.make_bucket(bucket_name=bucket)
+
+
+@pytest.mark.parametrize('access_key, bucket', [
+    pytest.param('ppd_user1', 'ppd-staging', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'ppd-staging', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_user1', 'dominode-staging', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'dominode-staging', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_user1', 'public', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'public', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+])
+def test_user_cannot_delete_bucket(
+        bootstrapped_minio_server,
+        minio_users_credentials,
+        minio_server_info,
+        access_key,
+        bucket
+):
+    minio_client = _get_minio_client(
+        access_key, minio_users_credentials, minio_server_info
+    )
+    minio_client.remove_bucket(bucket)
+
+
+@pytest.mark.parametrize('access_key, bucket_path', [
+    pytest.param('ppd_user1', 'ppd-staging/file1.txt', id='t91.1'),
+    pytest.param('ppd_user1', 'ppd-staging/somedir/file2.txt', id='t83, t91.2'),
+    pytest.param('ppd_editor1', 'ppd-staging/file3.txt', id='t92.1'),
+    pytest.param('ppd_editor1', 'ppd-staging/somedir/file4.txt', id='t84, t92.2'),
+    pytest.param('ppd_user1', 'dominode-staging/ppd/file1.txt', id='t119.1'),
+    pytest.param('ppd_user1', 'dominode-staging/ppd/somedir/file2.txt', id='t111, t119.2'),
+    pytest.param('ppd_editor1', 'dominode-staging/ppd/file3.txt', id='t120.1'),
+    pytest.param('ppd_editor1', 'dominode-staging/ppd/somedir/file4.txt', id='t112, t120.2'),
+    pytest.param('ppd_editor1', 'public/ppd/file3.txt', id='t148.1'),
+    pytest.param('ppd_editor1', 'public/ppd/somedir/file4.txt', id='t140, t148.2'),
+])
+def test_user_is_able_to_put_file_in_bucket(
+        bootstrapped_minio_server,
+        minio_users_credentials: typing.Dict,
+        minio_server_info: typing.Dict,
+        minio_admin_client: minio.Minio,
+        access_key: str,
+        bucket_path: str,
+):
+    minio_client = _get_minio_client(
+        access_key, minio_users_credentials, minio_server_info
+    )
+    bucket_name, object_path = bucket_path.partition('/')[::2]
+    _create_file(minio_client, bucket_name, object_path)
+    minio_admin_client.remove_object(bucket_name, object_path)
+
+
+@pytest.mark.parametrize('access_key, bucket_path', [
+    pytest.param('ppd_user1', 'ppd-staging/file1.txt', id='t93.1'),
+    pytest.param('ppd_user1', 'ppd-staging/somedir/file2.txt', id='t85, t93.2'),
+    pytest.param('ppd_editor1', 'ppd-staging/file3.txt', id='t94.1'),
+    pytest.param('ppd_editor1', 'ppd-staging/somedir/file4.txt', id='t86, t94.2'),
+    pytest.param('ppd_user1', 'dominode-staging/ppd/file1.txt', id='t121.1'),
+    pytest.param('ppd_user1', 'dominode-staging/ppd/somedir/file2.txt', id='t113, t121.2'),
+    pytest.param('ppd_editor1', 'dominode-staging/ppd/file3.txt', id='t122.1'),
+    pytest.param('ppd_editor1', 'dominode-staging/ppd/somedir/file4.txt', id='t114, t122.2'),
+    pytest.param('ppd_editor1', 'public/ppd/file3.txt', id='t150.1'),
+    pytest.param('ppd_editor1', 'public/ppd/somedir/file4.txt', id='t142, t150.2'),
+])
+def test_user_is_able_to_delete_file_from_bucket(
+        bootstrapped_minio_server,
+        minio_users_credentials: typing.Dict,
+        minio_server_info: typing.Dict,
+        access_key: str,
+        bucket_path: str
+):
+    minio_client = _get_minio_client(
+        access_key, minio_users_credentials, minio_server_info
+    )
+    bucket_name, object_path = bucket_path.partition('/')[::2]
+    _create_file(minio_client, bucket_name, object_path)
+    minio_client.remove_object(bucket_name, object_path)
+
+
+@pytest.mark.parametrize('creator, accessor, bucket_path', [
+    pytest.param('ppd_user1', 'ppd_user2', 'ppd-staging/file1.txt', id='t89.1'),
+    pytest.param('ppd_editor1', 'ppd_user2', 'ppd-staging/file2.txt', id='t89.2'),
+    pytest.param('ppd_user1', 'ppd_editor1', 'ppd-staging/file3.txt', id='t90.1'),
+    pytest.param('ppd_editor1', 'ppd_editor2', 'ppd-staging/file4.txt', id='t90.2'),
+    pytest.param('ppd_user1', 'ppd_user2', 'dominode-staging/ppd/file5.txt', id='t117.1'),
+    pytest.param('ppd_editor1', 'ppd_user2', 'dominode-staging/ppd/file6.txt', id='t117.2'),
+    pytest.param('ppd_editor1', 'ppd_editor2', 'dominode-staging/ppd/file7.txt', id='t118.1'),
+    pytest.param('ppd_user1', 'lsd_user1', 'dominode-staging/ppd/file8.txt', id='t131'),
+    pytest.param('ppd_user1', 'lsd_editor1', 'dominode-staging/ppd/file9.txt', id='t132'),
+    pytest.param('ppd_editor1', 'ppd_user1', 'public/ppd/file10.txt', id='t145'),
+    pytest.param('ppd_editor1', 'ppd_editor2', 'public/ppd/file11.txt', id='t146'),
+    pytest.param('ppd_editor1', 'lsd_user1', 'public/ppd/file12.txt', id='t159'),
+    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/file13.txt', id='t160'),
+])
+def test_user_is_able_to_access_file(
+        bootstrapped_minio_server,
+        minio_users_credentials: typing.Dict,
+        minio_server_info: typing.Dict,
+        creator: str,
+        accessor: str,
+        bucket_path: str
+):
+    creator_minio_client = _get_minio_client(
+        creator, minio_users_credentials, minio_server_info)
+    bucket_name, object_path = bucket_path.partition('/')[::2]
+    contents = 'hello world'
+    _create_file(
+        creator_minio_client, bucket_name, object_path, contents=contents)
+    accessor_minio_client = _get_minio_client(
+        accessor, minio_users_credentials, minio_server_info)
+    data: HTTPResponse = accessor_minio_client.get_object(bucket_name, object_path)
+    buffer = io.StringIO()
+    for chunk in data.stream(32 * 1024):
+        buffer.write(chunk.decode('utf-8'))
+    buffer.seek(0)
+    response = buffer.read()
+    assert response == contents
+    creator_minio_client.remove_object(bucket_name, object_path)
+
+
+def _create_file(
+        minio_client: minio.Minio,
+        bucket_name: str,
+        object_path: str,
+        contents: typing.Optional[str] = 'this is some sample content'
+):
+
+    buffer = io.BytesIO(bytes(contents, 'utf-8'))
+    buffer.seek(0, os.SEEK_END)
+    buffer_size = buffer.tell()
+    buffer.seek(0)
+    print(f'bucket_name: {bucket_name}')
+    print(f'object_path: {object_path}')
+    print(f'contents: {contents}')
+    print(f'buffer_size: {buffer_size}')
+    minio_client.put_object(
+        bucket_name,
+        object_path,
+        buffer,
+        buffer_size
+    )
+
+
 def _get_minio_client(
         access_key: str,
         minio_users_credentials: typing.Dict,
-        port: int,
+        minio_server_info: typing.Dict,
 ):
     secret_key = minio_users_credentials[access_key][0]
-    endpoint = f'localhost:{port}'
-    return Minio(
+    endpoint = f'localhost:{minio_server_info["port"]}'
+    return minio.Minio(
         endpoint=endpoint,
         access_key=access_key,
         secret_key=secret_key,

--- a/extra/dominode-extra/tests/test_bootstrap_minio.py
+++ b/extra/dominode-extra/tests/test_bootstrap_minio.py
@@ -221,6 +221,7 @@ def test_user_is_able_to_rename_file_directory(
     pytest.param('ppd_editor1', 'ppd_user2', 'dominode-staging/ppd/file1.txt', id='t123.2'),
     pytest.param('ppd_user1', 'ppd_editor1', 'dominode-staging/ppd/file1.txt', id='t124.1'),
     pytest.param('ppd_editor1', 'ppd_editor2', 'dominode-staging/ppd/file1.txt', id='t124.2'),
+    pytest.param('ppd_editor1', 'ppd_editor2', 'public/ppd/file1.txt', id='t152'),
 ])
 def test_user_is_able_to_edit_file(
         bootstrapped_minio_server,
@@ -301,8 +302,16 @@ def _create_file(
     pytest.param('ppd_user1', 'dominode-staging/lsd/somedir/file2.txt', id='t125, t133.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_editor1', 'dominode-staging/lsd/file3.txt', id='t134.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_editor1', 'dominode-staging/lsd/somedir/file4.txt', id='t126, t134.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
-    pytest.param('ppd_editor1', 'public/lsd/file3.txt', id='t147.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
-    pytest.param('ppd_editor1', 'public/lsd/somedir/file4.txt', id='t139, t147.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+
+    pytest.param('ppd_user1', 'public/ppd/file3.txt', id='t147.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_user1', 'public/ppd/somedir/file3.txt', id='t139, t147.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+
+    pytest.param('ppd_user1', 'public/lsd/file3.txt', id='t161.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_user1', 'public/lsd/somedir/file4.txt', id='t153, t161.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+
+    pytest.param('ppd_editor1', 'public/lsd/file3.txt', id='t162.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'public/lsd/somedir/file4.txt', id='t154, t162.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+
 ])
 def test_user_is_not_able_to_put_file_in_bucket_owned_by_another_department(
         bootstrapped_minio_server,
@@ -328,8 +337,12 @@ def test_user_is_not_able_to_put_file_in_bucket_owned_by_another_department(
     pytest.param('ppd_user1', 'lsd_user1', 'dominode-staging/ppd/somedir/file2.txt', id='t127, t135.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_editor1', 'lsd_editor1', 'dominode-staging/ppd/file3.txt', id='t136.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_editor1', 'lsd_editor1', 'dominode-staging/ppd/somedir/file4.txt', id='t128, t136.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
-    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/file3.txt', id='t149.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
-    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/somedir/file4.txt', id='t141, t149.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'ppd_user1', 'public/ppd/file3.txt', id='t149.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'ppd_user1', 'public/ppd/somedir/file4.txt', id='t141, t149.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'lsd_user1', 'public/ppd/file3.txt', id='t163.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/file3.txt', id='t164.1', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'lsd_user1', 'public/ppd/somedir/file4.txt', id='t155, t163.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/somedir/file4.txt', id='t156, t164.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
 ])
 def test_user_is_not_able_to_delete_file_from_bucket_owned_by_another_department(
         bootstrapped_minio_server,
@@ -358,7 +371,12 @@ def test_user_is_not_able_to_delete_file_from_bucket_owned_by_another_department
     pytest.param('ppd_user1', 'lsd_editor1', 'ppd-staging/file1.txt', 'ppd-staging/extra/file1.txt', id='t102', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_user1', 'lsd_user1', 'dominode-staging/ppd/file1.txt', 'dominode-staging/ppd/extra/file1.txt', id='t129', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_user1', 'lsd_editor1', 'dominode-staging/ppd/file1.txt', 'dominode-staging/ppd/extra/file1.txt', id='t130', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
-    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/file1.txt', 'public/ppd/extra/file1.txt', id='t143', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+
+    pytest.param('ppd_editor1', 'ppd_user1', 'public/ppd/file1.txt', 'public/ppd/extra/file1.txt', id='t143', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+
+    pytest.param('ppd_editor1', 'lsd_user1', 'public/ppd/file1.txt', 'public/ppd/extra/file1.txt', id='t157', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/file1.txt', 'public/ppd/extra/file1.txt', id='t158', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+
 ])
 def test_user_is_not_able_to_rename_file_directory_on_buckets_owned_by_another_department(
         bootstrapped_minio_server,
@@ -445,6 +463,7 @@ def test_user_is_not_able_to_access_file_on_buckets_owned_by_another_department(
     pytest.param('ppd_editor1', 'lsd_editor1', 'dominode-staging/ppd/file1.txt', id='t138.2', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_editor1', 'ppd_user1', 'public/ppd/file1.txt', id='t151', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
     pytest.param('ppd_editor1', 'lsd_user1', 'public/ppd/file1.txt', id='t165', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
+    pytest.param('ppd_editor1', 'lsd_editor1', 'public/ppd/file1.txt', id='t166', marks=pytest.mark.raises(exception=minio.error.AccessDenied)),
 
 ])
 def test_user_is_not_able_to_edit_file(

--- a/extra/dominode-extra/tests/test_bootstrap_minio.py
+++ b/extra/dominode-extra/tests/test_bootstrap_minio.py
@@ -1,7 +1,35 @@
+import typing
+
 import pytest
+from minio import Minio
 
 
-def test_minio_server_comes_up(minio_client, bootstrapped_minio_server):
+@pytest.mark.parametrize('access_key, expected_num_buckets', [
+    pytest.param('ppd_user1', 2)
+])
+def test_regular_user_has_access_to_buckets(
+        minio_server_info,
+        bootstrapped_minio_server,
+        minio_users_credentials,
+        access_key,
+        expected_num_buckets
+):
+    minio_client = _get_minio_client(access_key, minio_users_credentials, minio_server_info['port'])
     buckets = minio_client.list_buckets()
     print(f'buckets: {buckets}')
-    assert len(buckets) > 0
+    assert len(buckets) == expected_num_buckets
+
+
+def _get_minio_client(
+        access_key: str,
+        minio_users_credentials: typing.Dict,
+        port: int,
+):
+    secret_key = minio_users_credentials[access_key][0]
+    endpoint = f'localhost:{port}'
+    return Minio(
+        endpoint=endpoint,
+        access_key=access_key,
+        secret_key=secret_key,
+        secure=False,
+    )


### PR DESCRIPTION
This PR adds the `dominode-admin` cli command, which can be called to performvarious admin operations tailored to DomiNode.

### Bootstrapping minio

```
poetry run dominode-admin minio bootstrap --help
```

In order for this command to succeed you must have the [minIO-client] (`mc`) already installed and a suitable minIO configuration file created with the credentials for accessing the minIO server. More info on this in the [minIO client docs]. Briefly, you must have the `.mc/config.json` file created with contents similar to this:

```json
{
  "version": "9",
   "hosts": {
     "dominode-dev": {
       "url": "http://localhost:9100",
       "accessKey": "myuser",
       "secretKey": "mypassword",
       "api": "S3v4",
       "lookup": "auto"
     }
   }
}
```

minIO groups, buckets and and access permissions are specified in this spreadhseet:

https://docs.google.com/spreadsheets/d/1uiuey2w4IvCNtNK0rV2Z3e5IOk0TsbGrkQit9Cdic0o/edit#gid=643393779


### Bootstrapping the database

```
poetry run dominode-admin db bootstrap --help
```

In order for this command to succeed you must have a [postgresql service file] created with the suitable configuration

This PR merely refactred the already existing code for the bootstrapping of the database. The real work done here was on the minIO bootstrapping.


This is related to #25



[minIO-client]: https://dl.min.io/client/mc/release/linux-amd64/mc
[minIO client docs]: https://docs.min.io/docs/minio-client-quickstart-guide.html
[postgresql service file]: https://www.postgresql.org/docs/current/libpq-pgservice.html