### PR TITLE
Initial automation of GeoNode and GeoServer groups

### DIFF
--- a/extra/dominode-extra/dominode_extra/constants.py
+++ b/extra/dominode-extra/dominode_extra/constants.py
@@ -1,11 +1,16 @@
-from enum import Enum
+import enum
 
 
-class DepartmentName(Enum):
+class DepartmentName(enum.Enum):
     PPD = 'ppd'
     LSD = 'lsd'
 
 
-class UserRole(str, Enum):
+class UserRole(str, enum.Enum):
     REGULAR_DEPARTMENT_USER = 'regular_department_user'
     EDITOR = 'editor'
+
+
+class GeofenceAccess(enum.Enum):
+    ADMIN = enum.auto()
+    USER = enum.auto()

--- a/extra/dominode-extra/dominode_extra/dominodeadmin.py
+++ b/extra/dominode-extra/dominode_extra/dominodeadmin.py
@@ -3,12 +3,16 @@
 import typer
 from pathlib import Path
 
-from . import minioadmin
-from . import dbadmin
+from . import (
+    dbadmin,
+    geonodeadmin,
+    minioadmin,
+)
 
 app = typer.Typer()
-app.add_typer(minioadmin.app, name='minio')
 app.add_typer(dbadmin.app, name='db')
+app.add_typer(geonodeadmin.app, name='geonode')
+app.add_typer(minioadmin.app, name='minio')
 
 
 @app.command()

--- a/extra/dominode-extra/dominode_extra/geonodeadmin.py
+++ b/extra/dominode-extra/dominode_extra/geonodeadmin.py
@@ -1,0 +1,335 @@
+"""Extra admin commands to manage GeoNode and GeoServer.
+
+This script adds some functions to perform DomiNode related tasks in a more
+expedite manner.
+
+"""
+
+import typing
+from pathlib import Path
+
+import httpx
+import typer
+
+from .constants import (
+    DepartmentName,
+    GeofenceAccess,
+    UserRole,
+)
+
+_help_intro = 'Manage GeoNode'
+
+app = typer.Typer(
+    short_help=_help_intro,
+    help=_help_intro
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_BASE_URL = 'http://localhost'
+DEFAULT_USERNAME = 'admin'
+DEFAULT_PASSWORD = 'admin'
+_ANY = '*'
+
+
+class GeoNodeManager:
+    client: httpx.Client
+    base_url: str
+    username: str
+    password: str
+    geoserver_application_client_id: str
+    geoserver_application_client_secret: str
+
+    def __init__(
+            self,
+            client: httpx.Client,
+            base_url: str = DEFAULT_BASE_URL,
+            username: str = DEFAULT_USERNAME,
+            password: str = DEFAULT_PASSWORD,
+            geoserver_client_id: str = None,
+            geoserver_client_secret: str = None,
+    ):
+        self.client = client
+        self.base_url = (
+            base_url if not base_url.endswith('/') else base_url.rstrip('/'))
+        self.username = username
+        self.password = password
+        self.geoserver_application_client_id = geoserver_client_id
+        self.geoserver_application_client_secret = geoserver_client_secret
+
+    def login(self) -> httpx.Response:
+        return self._modify_server_state(
+            f'{self.base_url}/account/login/',
+            login=self.username,
+            password=self.password
+        )
+
+    def logout(self) -> httpx.Response:
+        return self._modify_server_state(f'{self.base_url}/account/logout/')
+
+    def get_existing_groups(
+            self,
+            pagination_url: str = None
+    ) -> typing.List[typing.Dict]:
+        """Retrieve existing groups via GeoNode's REST API"""
+        url = pagination_url or f'{self.base_url}/api/group_profile/'
+        response = self.client.get(url)
+        response.raise_for_status()
+        payload = response.json()
+        group_profiles: typing.List = payload['objects']
+        next_page = payload['meta']['next']
+        if next_page is not None:
+            group_profiles.extend(self.get_existing_groups(next_page))
+        return group_profiles
+
+    def create_group(self, name: str, description: str) -> httpx.Response:
+        """Create a new GeoNode group.
+
+        The GeoNode REST API does not have a way to create new groups. As such,
+        as a workaround measure, we impersonate a web browser and create the
+        group using the main GUI.
+
+        """
+
+        return self._modify_server_state(
+            f'{self.base_url}/groups/create/',
+            title=name,
+            description=description,
+            access='public-invite'
+        )
+
+    def get_geoserver_access_token(self) -> str:
+        response = self.client.post(
+            f'{self.base_url}/o/token/',
+            data={
+                'grant_type': 'password',
+                'username': self.username,
+                'password': self.password,
+            },
+            auth=(
+                self.geoserver_application_client_id,
+                self.geoserver_application_client_secret
+            )
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload['access_token']
+
+    def _modify_server_state(self, url: str, **data):
+        """Modify GeoNode state.
+
+        This function is used in the context of making web requests as if we
+        were a web browser.
+
+        This function is tailored to the way django CSRF security features
+        behave. It first makes a GET request to the specified URL in order to
+        retrieve the appropriate CSRF token from the response's cookies. Then
+        it makes the actual POST request, with the data to modify the backend.
+        This second request sends back the CSRF token, which proves to django
+        that the request is legitimate.
+
+        """
+
+        idempotent_response = self.client.get(url)
+        idempotent_response.raise_for_status()
+        request_data = data.copy()
+        request_data.update({
+            'csrfmiddlewaretoken': idempotent_response.cookies['csrftoken'],
+        })
+        modifier_response = self.client.post(
+            url,
+            data=request_data,
+            headers={
+                'Referer': url,
+            },
+            cookies=idempotent_response.cookies
+        )
+        return modifier_response
+
+
+class GeoServerManager:
+    client: httpx.Client
+    base_url: str
+    access_token: str
+
+    def __init__(
+            self,
+            client: httpx.Client,
+            base_url: str,
+            access_token: typing.Optional[str] = None
+    ):
+        self.client = client
+        self.client.headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+        self.base_url = base_url
+        self.access_token = access_token
+
+    @classmethod
+    def from_geonode_manager(cls, geonode_manager: GeoNodeManager):
+        access_token = geonode_manager.get_geoserver_access_token()
+        return cls(
+            geonode_manager.client,
+            f'{geonode_manager.base_url}/geoserver',
+            access_token
+        )
+
+    def list_workspaces(self):
+        raise NotImplementedError  # TODO: Provide implementation
+
+    def create_workspace(self):
+        raise NotImplementedError  # TODO: Provide implementation
+
+    def create_postgis_store(self):
+        raise NotImplementedError  # TODO: Provide implementation
+
+    def list_geofence_admin_rules(self) -> typing.List:
+        response = self.client.get(
+            f'{self.base_url}/rest/geofence/adminrules',
+            headers={
+                'Authorization': f'Bearer {self.access_token}'
+            }
+        )
+        response.raise_for_status()
+        return response.json().get('rules', [])
+
+    def create_geofence_admin_rule(
+            self,
+            workspace: str,
+            role_name: str,
+            role: UserRole,
+    ):
+        if role == UserRole.EDITOR:
+            access = GeofenceAccess.ADMIN
+        else:
+            access = GeofenceAccess.USER
+        response = self.client.post(
+            f'{self.base_url}/rest/geofence/adminrules/',
+            json={
+                'priority': 0,
+                'userName': _ANY,
+                'roleName': role_name,
+                'addressRange': _ANY,
+                'workspace': workspace,
+                'access': access.name
+            }
+        )
+        response.raise_for_status()
+        return response
+
+
+@app.command()
+def bootstrap(
+        base_url: str = DEFAULT_BASE_URL,
+        username: str = DEFAULT_USERNAME,
+        password: str = DEFAULT_PASSWORD
+):
+    """Perform initial bootstrap of GeoNode and GeoServer"""
+    internal_group_name = 'dominode-internal'
+    with httpx.Client() as client:
+        geonode_manager = GeoNodeManager(client, base_url, username, password)
+        geonode_manager.login()
+        existing_groups = geonode_manager.get_existing_groups()
+        for department in DepartmentName:
+            _add_department(
+                geonode_manager,
+                department, [i['title'] for i in existing_groups]
+            )
+        typer.echo(f'Creating group {internal_group_name!r}...')
+        geonode_manager.create_group(
+            internal_group_name,
+            'A group for internal DomiNode users'
+        )
+        geonode_manager.logout()
+    pass
+
+
+@app.command()
+def add_department(
+        department: DepartmentName,
+        base_url: str = DEFAULT_BASE_URL,
+        username: str = DEFAULT_USERNAME,
+        password: str = DEFAULT_PASSWORD,
+):
+    with httpx.Client() as client:
+        manager = GeoNodeManager(client, base_url, username, password)
+        manager.login()
+        existing_groups = manager.get_existing_groups()
+        _add_department(
+            manager,
+            department,
+            [i['title'] for i in existing_groups]
+        )
+        manager.logout()
+
+
+def get_geonode_group_name(department: DepartmentName) -> str:
+    return f'{department.value}-editor'
+
+
+def get_geoserver_group_name(department: DepartmentName) -> str:
+    return get_geonode_group_name(department).upper()
+
+
+def _add_department(
+        manager: GeoNodeManager,
+        department: DepartmentName,
+        existing_groups: typing.List[str]
+):
+    group_name = get_geonode_group_name(department)
+    description = (
+        f'A group for users that are allowed to administer {department.value} '
+        f'datasets'
+    )
+    if group_name not in existing_groups:
+        typer.echo(f'Creating group {group_name!r}...')
+        manager.create_group(group_name, description)
+        geoserver_manager = GeoServerManager.from_geonode_manager(manager)
+        _bootstrap_department_in_geoserver(geoserver_manager, department)
+    else:
+        typer.echo(f'group {group_name!r} already exists, ignoring...')
+
+
+def _bootstrap_department_in_geoserver(
+        manager: GeoServerManager,
+        department: DepartmentName
+):
+    """Bootstrap a department in GeoServer
+
+    This function performs the following steps:
+
+    1. create geoserver workspace, in case it does not already exist. If the
+       workspace already exists, the function shall return immediately.
+
+    2. Create the relevant geofence admin rules for the workspace -
+       The `{department}-editor` group shall be able to administer the
+       corresponding workspace.
+
+    3. Create a postgis store in the workspace - this requires using specific
+       DB credentials, which provide specific access controls - the DB user
+       that is used for each department workspace shall only be able to access
+       layers on the **public** schema of the DB AND the user shall only be
+       allowed to access layers owned by his own department AND even this
+       access must be readonly.
+
+    """
+
+    # TODO: Needs additional work on the database bootstrap script.
+    #  Create a `{department}-geoserver` DB user, which shall have readonly
+    #  access to department layers on the `public` schema only
+
+    existing_workspaces = manager.list_workspaces()
+    workspace_name = department.value
+    workspace_exists = False
+    # TODO: check if the workspace that we want to create already exists and do not continue if it does
+    # 1. create the workspace
+
+    if not workspace_exists:
+        # 2. create the geofence admin rules
+        existing_rules = manager.list_geofence_admin_rules()
+        group_name = get_geoserver_group_name(department)
+        role_name = f'ROLE_{group_name}'
+        if role_name not in [i['roleName'] for i in existing_rules]:
+            manager.create_geofence_admin_rule(
+                department.value, role_name, UserRole.EDITOR)
+        # 3. create the postgis db store

--- a/extra/dominode-extra/poetry.lock
+++ b/extra/dominode-extra/poetry.lock
@@ -39,7 +39,7 @@ python-versions = "*"
 version = "0.2.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
@@ -47,7 +47,7 @@ python-versions = "*"
 version = "2020.6.20"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
 optional = false
@@ -113,7 +113,49 @@ ssh = ["paramiko (>=2.4.2)"]
 tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
 
 [[package]]
-category = "dev"
+category = "main"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+name = "h11"
+optional = false
+python-versions = "*"
+version = "0.9.0"
+
+[[package]]
+category = "main"
+description = "A minimal low-level HTTP client."
+name = "httpcore"
+optional = false
+python-versions = ">=3.6"
+version = "0.10.1"
+
+[package.dependencies]
+h11 = ">=0.8,<0.10"
+sniffio = ">=1.0.0,<2.0.0"
+
+[package.extras]
+http2 = ["h2 (>=3.0.0,<4.0.0)"]
+
+[[package]]
+category = "main"
+description = "The next generation HTTP client."
+name = "httpx"
+optional = false
+python-versions = ">=3.6"
+version = "0.14.1"
+
+[package.dependencies]
+certifi = "*"
+chardet = ">=3.0.0,<4.0.0"
+httpcore = ">=0.10.0,<0.11.0"
+idna = ">=2.0.0,<3.0.0"
+rfc3986 = ">=1.3,<2"
+sniffio = "*"
+
+[package.extras]
+http2 = ["h2 (>=3.0.0,<4.0.0)"]
+
+[[package]]
+category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
@@ -399,12 +441,31 @@ security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
+category = "main"
+description = "Validating URI References per RFC 3986"
+name = "rfc3986"
+optional = false
+python-versions = "*"
+version = "1.4.0"
+
+[package.extras]
+idna2008 = ["idna"]
+
+[[package]]
 category = "dev"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "1.15.0"
+
+[[package]]
+category = "main"
+description = "Sniff out which async library your code is running under"
+name = "sniffio"
+optional = false
+python-versions = ">=3.5"
+version = "1.1.0"
 
 [[package]]
 category = "dev"
@@ -492,7 +553,7 @@ version = "0.57.0"
 six = "*"
 
 [metadata]
-content-hash = "0009e610db238f4b702a21644fa9fe8775b97936bddf2c0b2635b48d5a4d7378"
+content-hash = "0e3a2f4041a3e2ffd0a5c4093a7b685cb44aa47c5a9c685b08e5b27e82de9116"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -539,6 +600,18 @@ decorator = [
 docker = [
     {file = "docker-4.2.2-py2.py3-none-any.whl", hash = "sha256:03a46400c4080cb6f7aa997f881ddd84fef855499ece219d75fbdb53289c17ab"},
     {file = "docker-4.2.2.tar.gz", hash = "sha256:26eebadce7e298f55b76a88c4f8802476c5eaddbdbe38dbc6cce8781c47c9b54"},
+]
+h11 = [
+    {file = "h11-0.9.0-py2.py3-none-any.whl", hash = "sha256:4bc6d6a1238b7615b266ada57e0618568066f57dd6fa967d1290ec9309b2f2f1"},
+    {file = "h11-0.9.0.tar.gz", hash = "sha256:33d4bca7be0fa039f4e84d50ab00531047e53d6ee8ffbc83501ea602c169cae1"},
+]
+httpcore = [
+    {file = "httpcore-0.10.1-py3-none-any.whl", hash = "sha256:73f506efa04023af0385ee71539f8e0eed12dadca100f3394358f3f7ef68273e"},
+    {file = "httpcore-0.10.1.tar.gz", hash = "sha256:85295a081d5cca79b1a4d5190456bc869f2f220170b7749e882ac880b087a600"},
+]
+httpx = [
+    {file = "httpx-0.14.1-py3-none-any.whl", hash = "sha256:2be72b6932f185319031a553a474c298df3982a6ad8b23e6477a832cd2e54067"},
+    {file = "httpx-0.14.1.tar.gz", hash = "sha256:0c557173821c1e453396325b3fef768d2bca9078f7300d431735177654e0f9b1"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -675,9 +748,17 @@ requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
     {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
+rfc3986 = [
+    {file = "rfc3986-1.4.0-py2.py3-none-any.whl", hash = "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"},
+    {file = "rfc3986-1.4.0.tar.gz", hash = "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d"},
+]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+sniffio = [
+    {file = "sniffio-1.1.0-py3-none-any.whl", hash = "sha256:20ed6d5b46f8ae136d00b9dcb807615d83ed82ceea6b2058cecb696765246da5"},
+    {file = "sniffio-1.1.0.tar.gz", hash = "sha256:8e3810100f69fe0edd463d02ad407112542a11ffdc29f67db2bf3771afb87a21"},
 ]
 sqlalchemy = [
     {file = "SQLAlchemy-1.3.18-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:f11c2437fb5f812d020932119ba02d9e2bc29a6eca01a055233a8b449e3e1e7d"},

--- a/extra/dominode-extra/pyproject.toml
+++ b/extra/dominode-extra/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 typer = "^0.3.0"
+httpx = "^0.14.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
@@ -17,9 +18,9 @@ ipython = "^7.16.1"
 pytest-raises = "^0.11"
 minio = "^5.0.10"
 
+[tool.poetry.scripts]
+dominode-admin = 'dominode_extra.dominodeadmin:app'
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
-
-[tool.poetry.scripts]
-dominode-admin = 'dominode_extra.dominodeadmin:app'

--- a/sql/bootstrap-db.sql
+++ b/sql/bootstrap-db.sql
@@ -162,7 +162,7 @@ CREATE OR REPLACE FUNCTION setStagingPermissions(qualifiedTableName varchar) RET
 CREATE OR REPLACE FUNCTION moveTableToDominodeStagingSchema(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
     -- Move a table from a department's internal schema to the project-wide internal staging schema
     --
-    -- Tables in the department's staging schema are only readable by deparment members, while those
+    -- Tables in the department's staging schema are only readable by department members, while those
     -- on the project-wide staging schema are readable by all users (but they are only editable by
     -- department members).
     --


### PR DESCRIPTION
This PR implements the first part of the GeoNode/GeoServer bootstrapping process:

-  Provides the `geonodeadmin.py` script, which is already hooked up to the `dominode-admin` CLI utility

   ```
   poetry run dominode-admin geonode bootstrap
   ```

-  Generates GeoNode groups by using its GUI. This is a hacky way to do it, since GeoNode's REST API does not support creating groups. Nevertheless, it works and allows us to move forward

-  Provides a way to use the GeoServer REST API by logging in via OAuth, by using the GeoNode admin credentials. This requires an additional step when setting up GeoNode, which we will need to perform (I will open an issue for that). Basically we need to configure an additional OAuth application and give it a grant type of `Resource owner password based`. This application shall only be used to manage GeoServer via CLI.

-  Includes extensive comments and a skeleton for @Samweli to follow and proceed with implementing the GeoServer REST API stuff.