### PR TITLE
76 add additional db users for geoserver

### DIFF
--- a/dominode-bootstrapper/dominode_bootstrapper/constants.py
+++ b/dominode-bootstrapper/dominode_bootstrapper/constants.py
@@ -1,6 +1,7 @@
 import enum
 
 
+# TODO: Remove this
 class DepartmentName(enum.Enum):
     PPD = 'ppd'
     LSD = 'lsd'

--- a/dominode-bootstrapper/dominode_bootstrapper/dbadmin.py
+++ b/dominode-bootstrapper/dominode_bootstrapper/dbadmin.py
@@ -32,8 +32,8 @@ config = utils.load_config()
 
 @app.command()
 def bootstrap(
-        db_username: typing.Optional[str] = config['db']['admin_username'],
-        db_password: typing.Optional[str] = config['db']['admin_password'],
+        db_admin_username: typing.Optional[str] = config['db']['admin_username'],
+        db_admin_password: typing.Optional[str] = config['db']['admin_password'],
         db_name: typing.Optional[str] = config['db']['name'],
         db_host: str = config['db']['host'],
         db_port: int = config['db']['port'],
@@ -46,8 +46,8 @@ def bootstrap(
     """
 
     db_url = (
-        f'postgresql://{db_username}:{db_password}@{db_host}:{db_port}/'
-        f'{db_name or db_username}'
+        f'postgresql://{db_admin_username}:{db_admin_password}@'
+        f'{db_host}:{db_port}/{db_name or db_admin_username}'
     )
     dominode_staging_schema_name = 'dominode_staging'
     with get_db_connection(db_url) as db_connection:

--- a/dominode-bootstrapper/dominode_bootstrapper/dbadmin.py
+++ b/dominode-bootstrapper/dominode_bootstrapper/dbadmin.py
@@ -6,7 +6,6 @@ expedite manner than using the bare `psql` client
 """
 
 import typing
-from configparser import ConfigParser
 from contextlib import contextmanager
 from pathlib import Path
 from time import sleep
@@ -14,11 +13,11 @@ from time import sleep
 import sqlalchemy as sla
 import typer
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.sql import text
+from sqlalchemy.engine import Connection
 
-from .constants import (
-    DepartmentName,
-    UserRole,
-)
+from .constants import UserRole
+from . import utils
 
 _help_intro = 'Manage postgis database'
 
@@ -28,16 +27,16 @@ app = typer.Typer(
 )
 
 APP_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_DB_SERVICE_FILE = Path('~/.pg_service.conf').expanduser()
+config = utils.load_config()
 
 
 @app.command()
 def bootstrap(
-        db_username: str,
-        db_password: str,
-        db_name: typing.Optional[str] = None,
-        db_host: str = 'localhost',
-        db_port: int = 5432,
+        db_username: typing.Optional[str] = config['db']['admin_username'],
+        db_password: typing.Optional[str] = config['db']['admin_password'],
+        db_name: typing.Optional[str] = config['db']['name'],
+        db_host: str = config['db']['host'],
+        db_port: int = config['db']['port'],
 ):
     """Perform initial bootstrap of the database
 
@@ -50,11 +49,77 @@ def bootstrap(
         f'postgresql://{db_username}:{db_password}@{db_host}:{db_port}/'
         f'{db_name or db_username}'
     )
-    bootstrap_sql_path = APP_ROOT / 'sql/bootstrap-db.sql'
+    dominode_staging_schema_name = 'dominode_staging'
     with get_db_connection(db_url) as db_connection:
+        typer.echo('Creating general roles...')
+        create_role(
+            'admin', db_connection, other_options=('CREATEDB', 'CREATEROLE'))
+        create_role(
+            'replicator', db_connection, other_options=('REPLICATION',))
+        generic_user_name = 'dominode_user'
+        create_role(generic_user_name, db_connection)
+        generic_editor_role_name = 'editor'
+        create_role(
+            generic_editor_role_name,
+            db_connection,
+            other_options=('IN ROLE dominode_user', )
+        )
+        typer.echo(f'creating {dominode_staging_schema_name!r} schema...')
+        create_schema(
+            dominode_staging_schema_name,
+            generic_editor_role_name,
+            db_connection
+        )
+        typer.echo(
+            f'Granting permissions on {dominode_staging_schema_name!r} '
+            f'schema...'
+        )
+        grant_schema_permissions(
+            dominode_staging_schema_name,
+            ('USAGE', 'CREATE'),
+            generic_user_name, db_connection
+        )
+        for department in utils.get_departments(config):
+            user_role = f'{department}_user'
+            editor_role = f'{department}_editor'
+            typer.echo(f'Creating role {user_role!r}...')
+            create_role(
+                user_role, db_connection, parent_roles=('dominode_user',))
+            typer.echo(f'Creating role {editor_role!r}...')
+            create_role(
+                editor_role, db_connection, parent_roles=('editor', user_role))
+            typer.echo('Creating staging schemas...')
+            staging_schema_name = f'{department}_staging'
+            typer.echo(f'Creating {staging_schema_name!r} schema...')
+            create_schema(staging_schema_name, editor_role, db_connection)
+            typer.echo(f'Granting permissions...')
+            grant_schema_permissions(
+                staging_schema_name,
+                ('USAGE', 'CREATE'),
+                user_role,
+                db_connection
+            )
+            typer.echo(f'Adding GeoServer user accounts...')
+            geoserver_password = config[f'{department}-department'].get(
+                'geoserver_password', 'dominode')
+            create_user(
+                f'{department}_geoserver',
+                geoserver_password,
+                db_connection,
+                parent_roles=[generic_user_name]
+            )
+        typer.echo(f'Modifying access permissions on public schema...')
+        db_connection.execute(
+            text('REVOKE CREATE ON SCHEMA public FROM public'))
+        db_connection.execute(
+            text(
+                f'GRANT CREATE ON SCHEMA public TO {generic_editor_role_name}'
+            ),
+        )
+        typer.echo(f'Executing remaining SQL commands...')
         raw_connection = db_connection.connection
         raw_cursor = raw_connection.cursor()
-        typer.echo('Bootstrapping db...')
+        bootstrap_sql_path = APP_ROOT / 'sql/finalize-bootstrap-db.sql'
         raw_cursor.execute(bootstrap_sql_path.read_text())
         raw_connection.commit()
 
@@ -63,30 +128,94 @@ def bootstrap(
 def add_department_user(
         username: str,
         password: str,
-        department: DepartmentName,
-        admin_username: str,
-        admin_password: str,
+        department: str,
         role: typing.Optional[UserRole] = UserRole.REGULAR_DEPARTMENT_USER,
-        db_host: str = 'localhost',
-        db_port: int = 5432,
-        db_name: typing.Optional[str] = None,
+        db_admin_username: typing.Optional[str] = config['db']['admin_username'],
+        db_admin_password: typing.Optional[str] = config['db']['admin_password'],
+        db_host: typing.Optional[str] = config['db']['host'],
+        db_port: typing.Optional[int] = config['db']['port'],
+        db_name: typing.Optional[str] = config['db']['name'],
 ):
     db_url = (
-        f'postgresql://{admin_username}:{admin_password}@{db_host}:{db_port}/'
-        f'{db_name or admin_username}'
+        f'postgresql://{db_admin_username}:{db_admin_password}@'
+        f'{db_host}:{db_port}/{db_name or db_admin_username}'
     )
     sql_role = {
-        UserRole.EDITOR: f'{department.value}_editor',
-        UserRole.REGULAR_DEPARTMENT_USER: f'{department.value}_user',
+        UserRole.EDITOR: f'{department}_editor',
+        UserRole.REGULAR_DEPARTMENT_USER: f'{department}_user',
     }[role]
     with get_db_connection(db_url) as db_connection:
-        raw_connection = db_connection.connection
-        raw_cursor = raw_connection.cursor()
-        typer.echo(f'Creating user {username}...')
-        raw_cursor.execute(
-            f'CREATE USER {username} PASSWORD \'{password}\' IN ROLE {sql_role}'
+        create_user(username, password, db_connection, parent_roles=[sql_role])
+        # create_role(
+        #     username,
+        #     db_connection,
+        #     other_options=(
+        #         f'IN ROLE {sql_role}',
+        #         'LOGIN',
+        #         f'PASSWORD \'{password}\''
+        #     )
+        # )
+
+
+def create_role(
+        name: str,
+        connection: Connection,
+        parent_roles: typing.Optional[typing.Iterable[str]] = None,
+        other_options: typing.Optional[typing.Tuple] = None,
+):
+    if not check_for_role(name, connection):
+        options = f'WITH'
+        if parent_roles is not None:
+            options = f'{options} IN ROLE {", ".join(parent_roles)}'
+        if other_options is not None:
+            options = f'{options} {" ".join(other_options)}'
+        connection.execute(
+            text(f'CREATE ROLE {name} {options}')
         )
-        raw_connection.commit()
+    else:
+        typer.echo(f'Role {name!r} already exists. Skipping...')
+
+
+def create_user(
+        name: str,
+        password: str,
+        connection: Connection,
+        parent_roles: typing.Optional[typing.Iterable[str]] = None
+):
+    return create_role(
+        name,
+        connection,
+        parent_roles=parent_roles,
+        other_options=(
+            'LOGIN',
+            f'PASSWORD \'{password}\''
+        )
+    )
+
+
+def check_for_role(role: str, connection: Connection) -> bool:
+    """Check if role exists on the database"""
+    return connection.execute(
+        text('SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = :role)'),
+        role=role
+    ).scalar()
+
+
+def create_schema(name: str, owner_role: str, connection: Connection):
+    return connection.execute(
+        text(f'CREATE SCHEMA IF NOT EXISTS {name} AUTHORIZATION {owner_role}')
+    )
+
+
+def grant_schema_permissions(
+        schema: str,
+        permissions: typing.Iterable[str],
+        role: str,
+        connection: Connection
+):
+    return connection.execute(
+        text(f'GRANT {", ".join(permissions)} ON SCHEMA {schema} TO {role}')
+    )
 
 
 @contextmanager

--- a/dominode-bootstrapper/dominode_bootstrapper/dominodeadmin.py
+++ b/dominode-bootstrapper/dominode_bootstrapper/dominodeadmin.py
@@ -7,6 +7,7 @@ from . import (
     dbadmin,
     geonodeadmin,
     minioadmin,
+    utils,
 )
 
 app = typer.Typer()
@@ -14,33 +15,39 @@ app.add_typer(dbadmin.app, name='db')
 app.add_typer(geonodeadmin.app, name='geonode')
 app.add_typer(minioadmin.app, name='minio')
 
+config = utils.load_config()
+
 
 @app.command()
 def bootstrap(
-        db_user_name: str,
-        db_user_password: str,
-        minio_access_key: str,
-        minio_secret_key: str,
-        db_name: typing.Optional[str] = None,
-        db_host: str = 'localhost',
-        db_port: int = 5432,
+        db_admin_username: typing.Optional[str] = config[
+            'db']['admin_username'],
+        db_admin_password: typing.Optional[str] = config[
+            'db']['admin_password'],
+        db_name: typing.Optional[str] = config['db']['name'],
+        db_host: typing.Optional[str] = config['db']['host'],
+        db_port: typing.Optional[int] = config['db']['port'],
+        minio_admin_access_key: typing.Optional[str] = config[
+            'minio']['admin_access_key'],
+        minio_admin_secret_key: typing.Optional[str] = config[
+            'minio']['admin_secret_key'],
         minio_alias: typing.Optional[str] = 'dominode_bootstrapper',
-        minio_host: str = 'localhost',
-        minio_port: int = 9000,
-        minio_protocol: str = 'https'
+        minio_host: typing.Optional[str] = config['minio']['host'],
+        minio_port: typing.Optional[int] = config['minio']['port'],
+        minio_protocol: typing.Optional[str] = config['minio']['protocol']
 ):
     typer.echo('Bootstrapping DomiNode database...')
     dbadmin.bootstrap(
-        db_user_name,
-        db_user_password,
-        db_name or db_user_name,
-        db_host,
-        db_port
+        db_admin_username=db_admin_username,
+        db_admin_password=db_admin_password,
+        db_name=db_name,
+        db_host=db_host,
+        db_port=db_port
     )
     typer.echo('Bootstrapping DomiNode minIO...')
     minioadmin.bootstrap(
-        minio_access_key,
-        minio_secret_key,
+        minio_admin_access_key,
+        minio_admin_secret_key,
         minio_alias,
         minio_host,
         minio_port,

--- a/dominode-bootstrapper/dominode_bootstrapper/utils.py
+++ b/dominode-bootstrapper/dominode_bootstrapper/utils.py
@@ -1,0 +1,111 @@
+import os
+import typing
+from configparser import ConfigParser
+from pathlib import Path
+
+import typer
+
+from .constants import DepartmentName
+
+_DEFAULT_CONFIG_PATHS = (
+    Path('/etc/dominode/.dominode-bootstrapper.conf'),
+    Path('~/.dominode-bootstrapper.conf').expanduser(),
+    Path(__file__).resolve().parents[1] / '.dominode-bootstrapper.conf',
+    os.getenv('DOMINODE_BOOTSTRAPPER_CONFIG_PATH', '/dev/null'),
+)
+
+
+def load_config(
+        paths: typing.Optional[
+            typing.Iterable[typing.Union[str, Path]]
+        ] = _DEFAULT_CONFIG_PATHS
+) -> ConfigParser:
+    """Load configuration values
+
+    Config is composed by looking for values in multiple places:
+
+    - Default config values, as specified in the ``_get_default_config()``
+      function
+
+    - The following paths, if they exist:
+      - /etc/dominode/.dominode-bootstrapper.conf
+      - $HOME/.dominode-bootstrapper.conf
+      - {current-directory}/.dominode-bootstrapper.conf
+      - whatever file is specified by the DOMINODE_BOOTSTRAPPER_CONFIG_PATH
+        environment variable
+
+    - Environment variables named like `DOMINODE__{SECTION}__{KEY}`
+
+    """
+
+    config = _get_default_config()
+    read_from = config.read(paths)
+    typer.echo(f'Read config from {", ".join(read_from)}')
+    for section, section_options in get_config_from_env().items():
+        for key, value in section_options.items():
+            try:
+                config[section][key] = value
+            except KeyError:
+                config[section] = {key: value}
+    return config
+
+
+def get_config_from_env() -> typing.Dict[str, typing.Dict[str, str]]:
+    result = {}
+    for key, value in os.environ.items():
+        if key.startswith('DOMINODE__DEPARTMENT__'):
+            try:
+                department, config_key = key.split('__')[2:]
+            except ValueError:
+                typer.echo(f'Could not read variable {key}, ignoring...')
+                continue
+            section_name = f'{department.lower()}-department'
+            department_section = result.setdefault(section_name, {})
+            department_section[config_key.lower()] = value
+        elif key.startswith('DOMINODE__DB__'):
+            try:
+                config_key = key.split('__')[-1]
+            except ValueError:
+                typer.echo(f'Could not read variable {key}, ignoring...')
+                continue
+            db_section = result.setdefault('db', {})
+            db_section[config_key.lower()] = value
+        elif key.startswith('DOMINODE__MINIO__'):
+            try:
+                config_key = key.split('__')[-1]
+            except ValueError:
+                typer.echo(f'Could not read variable {key}, ignoring...')
+                continue
+            minio_section = result.setdefault('minio', {})
+            minio_section[config_key.lower()] = value
+    return result
+
+
+def _get_default_config():
+    config = ConfigParser()
+    for member in DepartmentName:
+        section_name = f'{member.value}-department'
+        config[section_name] = {}
+        config[section_name]['geoserver_password'] = "dominode"
+    config['db'] = {}
+    config['db']['name'] = 'postgres'
+    config['db']['host'] = 'localhost'
+    config['db']['port'] = '5432'
+    config['db']['admin_username'] = 'postgres'
+    config['db']['admin_password'] = 'postgres'
+    config['minio'] = {}
+    config['minio']['host'] = 'localhost'
+    config['minio']['port'] = '9000'
+    config['minio']['protocol'] = 'https'
+    config['minio']['admin_access_key'] = 'admin'
+    config['minio']['admin_secret_key'] = 'admin'
+    return config
+
+
+def get_departments(config: ConfigParser) -> typing.List[str]:
+    separator = '-'
+    result = []
+    for section in config.sections():
+        if section.endswith(f'{separator}department'):
+            result.append(section.partition(separator)[0])
+    return result

--- a/dominode-bootstrapper/sql/finalize-bootstrap-db.sql
+++ b/dominode-bootstrapper/sql/finalize-bootstrap-db.sql
@@ -26,7 +26,7 @@ GRANT SELECT ON public.layer_styles TO dominode_user;
 
 -- Create helper functions in order to facilitate loading datasets
 
-CREATE OR REPLACE FUNCTION setStagingPermissions(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
+CREATE OR REPLACE FUNCTION DomiNodeSetStagingPermissions(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
 --   1. assign ownership to the group role
 --
 --      ALTER TABLE ppd_staging."ppd_rrmap_v0.0.1-staging" OWNER TO ppd_editor;
@@ -55,7 +55,7 @@ CREATE OR REPLACE FUNCTION setStagingPermissions(qualifiedTableName varchar) RET
     LANGUAGE  plpgsql;
 
 
-CREATE OR REPLACE FUNCTION moveTableToDominodeStagingSchema(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
+CREATE OR REPLACE FUNCTION DomiNodeMoveTableToDominodeStagingSchema(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
     -- Move a table from a department's internal schema to the project-wide internal staging schema
     --
     -- Tables in the department's staging schema are only readable by department members, while those
@@ -71,7 +71,7 @@ BEGIN
     schemaName := split_part(qualifiedTableName, '.', 1);
     unqualifiedName := replace(qualifiedTableName, concat(schemaName, '.'), '');
     newQualifiedName := concat('dominode_staging.', format('%s', unqualifiedName));
-    PERFORM setStagingPermissions(qualifiedTableName);
+    PERFORM DomiNodeSetStagingPermissions(qualifiedTableName);
     EXECUTE format('ALTER TABLE %s SET SCHEMA dominode_staging', qualifiedTableName);
     EXECUTE format('GRANT SELECT ON %s TO dominode_user', newQualifiedName);
 
@@ -80,7 +80,7 @@ $functionBody$
     LANGUAGE  plpgsql;
 
 
-CREATE OR REPLACE FUNCTION moveTableToPublicSchema(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
+CREATE OR REPLACE FUNCTION DomiNodeMoveTableToPublicSchema(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
     -- Move a table from a department's internal schema to the public schema
     --
     -- Moved table is renamed and assigned proper permissions.
@@ -111,7 +111,7 @@ CREATE OR REPLACE FUNCTION moveTableToPublicSchema(qualifiedTableName varchar) R
     LANGUAGE  plpgsql;
 
 
-CREATE OR REPLACE FUNCTION copyTableBackToStagingSchema(qualifiedTableName varchar, newTableQualifiedName varchar) RETURNS VOID AS $functionBody$
+CREATE OR REPLACE FUNCTION DomiNodeCopyTableBackToStagingSchema(qualifiedTableName varchar, newTableQualifiedName varchar) RETURNS VOID AS $functionBody$
     -- Make a copy of the input table into the department's staging schema
     --
     -- This function shall be used whenever a table needs to be edited

--- a/dominode-bootstrapper/sql/finalize-bootstrap-db.sql
+++ b/dominode-bootstrapper/sql/finalize-bootstrap-db.sql
@@ -1,0 +1,151 @@
+-- DDL commands to bootstrap the DomiNode DB
+
+-- Create the `layer_styles` table which is used by QGIS to save styles
+CREATE TABLE IF NOT EXISTS public.layer_styles
+(
+    id                serial not null
+        constraint layer_styles_pkey
+            primary key,
+    f_table_catalog   varchar,
+    f_table_schema    varchar,
+    f_table_name      varchar,
+    f_geometry_column varchar,
+    stylename         text,
+    styleqml          xml,
+    stylesld          xml,
+    useasdefault      boolean,
+    description       text,
+    owner             varchar(63) default CURRENT_USER,
+    ui                xml,
+    update_time       timestamp   default CURRENT_TIMESTAMP
+);
+
+ALTER TABLE public.layer_styles OWNER TO editor;
+GRANT SELECT ON public.layer_styles TO dominode_user;
+
+
+-- Create helper functions in order to facilitate loading datasets
+
+CREATE OR REPLACE FUNCTION setStagingPermissions(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
+--   1. assign ownership to the group role
+--
+--      ALTER TABLE ppd_staging."ppd_rrmap_v0.0.1-staging" OWNER TO ppd_editor;
+--
+--   2. Grant relevant permissions to users
+--
+--      GRANT SELECT ON ppd_staging."ppd_rrmap_v0.0.1-staging" TO ppd_user;
+    DECLARE
+        unqualifiedName varchar;
+        schemaName varchar;
+        schemaDepartment varchar;
+        userRoleName varchar;
+    BEGIN
+        schemaName := split_part(qualifiedTableName, '.', 1);
+        unqualifiedName := replace(qualifiedTableName, concat(schemaName, '.'), '');
+        unqualifiedName := replace(unqualifiedName, '"', '');
+        schemaDepartment := split_part(unqualifiedName, '_', 1);
+        userRoleName := concat(schemaDepartment, '_user');
+        EXECUTE format('ALTER TABLE %s OWNER TO %I', qualifiedTableName, userRoleName);
+        IF schemaName = 'dominode_staging' THEN
+            EXECUTE format('GRANT SELECT ON %s TO dominode_user', qualifiedTableName);
+        END IF;
+    END
+
+    $functionBody$
+    LANGUAGE  plpgsql;
+
+
+CREATE OR REPLACE FUNCTION moveTableToDominodeStagingSchema(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
+    -- Move a table from a department's internal schema to the project-wide internal staging schema
+    --
+    -- Tables in the department's staging schema are only readable by department members, while those
+    -- on the project-wide staging schema are readable by all users (but they are only editable by
+    -- department members).
+    --
+
+DECLARE
+    schemaName varchar;
+    unqualifiedName varchar;
+    newQualifiedName varchar;
+BEGIN
+    schemaName := split_part(qualifiedTableName, '.', 1);
+    unqualifiedName := replace(qualifiedTableName, concat(schemaName, '.'), '');
+    newQualifiedName := concat('dominode_staging.', format('%s', unqualifiedName));
+    PERFORM setStagingPermissions(qualifiedTableName);
+    EXECUTE format('ALTER TABLE %s SET SCHEMA dominode_staging', qualifiedTableName);
+    EXECUTE format('GRANT SELECT ON %s TO dominode_user', newQualifiedName);
+
+END
+$functionBody$
+    LANGUAGE  plpgsql;
+
+
+CREATE OR REPLACE FUNCTION moveTableToPublicSchema(qualifiedTableName varchar) RETURNS VOID AS $functionBody$
+    -- Move a table from a department's internal schema to the public schema
+    --
+    -- Moved table is renamed and assigned proper permissions.
+    --
+    -- Example usage:
+    --
+    -- SELECT moveToPublicSchema('ppd_staging."ppd_schools_v0.0.1"')
+    --
+    --
+
+    DECLARE
+        schemaName varchar;
+        unqualifiedName varchar;
+        publicQualifiedName varchar;
+        ownerRole varchar;
+    BEGIN
+        schemaName := split_part(qualifiedTableName, '.', 1);
+        unqualifiedName := replace(qualifiedTableName, concat(schemaName, '.'), '');
+        unqualifiedName := replace(unqualifiedName, '"', '');
+        publicQualifiedName := concat('public.', format('%I', unqualifiedName));
+        EXECUTE format('SELECT tableowner FROM pg_tables where schemaname=%L AND tablename=%L', schemaName, unqualifiedName) INTO ownerRole;
+        EXECUTE format('ALTER TABLE %s SET SCHEMA public', qualifiedTableName);
+        EXECUTE format('GRANT SELECT ON %s TO public', publicQualifiedName);
+        EXECUTE format('REVOKE INSERT, UPDATE, DELETE ON %s FROM %I', publicQualifiedName, ownerRole);
+
+    END
+    $functionBody$
+    LANGUAGE  plpgsql;
+
+
+CREATE OR REPLACE FUNCTION copyTableBackToStagingSchema(qualifiedTableName varchar, newTableQualifiedName varchar) RETURNS VOID AS $functionBody$
+    -- Make a copy of the input table into the department's staging schema
+    --
+    -- This function shall be used whenever a table needs to be edited
+    --
+    -- Any department user should be able to copy a table back to its own
+    -- staging schema, regardless if the department owns the dataset or not.
+
+DECLARE
+    ownerRole varchar;
+BEGIN
+    ownerRole := concat(
+        split_part(
+            split_part(newTableQualifiedName, '.', 1),
+            '_',
+            1
+        ),
+        '_user'
+    );
+    EXECUTE format('CREATE TABLE %s (LIKE %s INCLUDING ALL)', newTableQualifiedName, qualifiedTableName);
+    EXECUTE format('INSERT INTO %s SELECT * FROM %s', newTableQualifiedName, qualifiedTableName);
+    EXECUTE format('ALTER TABLE %s OWNER TO %I', newTableQualifiedName, ownerRole);
+END
+$functionBody$
+    LANGUAGE  plpgsql;
+
+
+-- After the initial setup is done, perform the following:
+
+-- 1. Create initial users
+-- PPD users
+-- CREATE USER ppd_editor1 PASSWORD 'ppd_editor1' IN ROLE ppd_editor, admin;
+-- CREATE USER ppd_editor2 PASSWORD 'ppd_editor2' IN ROLE ppd_editor;
+-- CREATE USER ppd_user1 PASSWORD 'ppd_user1' IN ROLE ppd_user;
+-- LSD users
+-- CREATE USER lsd_editor1 PASSWORD 'lsd_editor1' IN ROLE lsd_editor;
+-- CREATE USER lsd_editor2 PASSWORD 'lsd_editor2' IN ROLE lsd_editor;
+-- CREATE USER lsd_user1 PASSWORD 'lsd_user1' IN ROLE lsd_user;

--- a/dominode-bootstrapper/tests/conftest.py
+++ b/dominode-bootstrapper/tests/conftest.py
@@ -106,8 +106,8 @@ def bootstrapped_db_connection(db_connection, db_admin_credentials):
     completed_process = subprocess.run(
         shlex.split(
             f'dominode-admin db bootstrap '
-            f'--db-username={db_admin_credentials["user"]} '
-            f'--db-password={db_admin_credentials["password"]} '
+            f'--db-admin-username={db_admin_credentials["user"]} '
+            f'--db-admin-password={db_admin_credentials["password"]} '
             f'--db-name={db_admin_credentials["db"]} '
             f'--db-host={db_admin_credentials["host"]} '
             f'--db-port={db_admin_credentials["port"]}'

--- a/dominode-bootstrapper/tests/conftest.py
+++ b/dominode-bootstrapper/tests/conftest.py
@@ -105,10 +105,12 @@ def db_connection(db_container, db_admin_credentials):
 def bootstrapped_db_connection(db_connection, db_admin_credentials):
     completed_process = subprocess.run(
         shlex.split(
-            f'dominode-admin db bootstrap {db_admin_credentials["user"]} '
-            f'{db_admin_credentials["password"]} {db_admin_credentials["db"]} '
-            f'--db-host {db_admin_credentials["host"]} '
-            f'--db-port {db_admin_credentials["port"]}'
+            f'dominode-admin db bootstrap '
+            f'--db-username={db_admin_credentials["user"]} '
+            f'--db-password={db_admin_credentials["password"]} '
+            f'--db-name={db_admin_credentials["db"]} '
+            f'--db-host={db_admin_credentials["host"]} '
+            f'--db-port={db_admin_credentials["port"]}'
         ),
         capture_output=True
     )
@@ -131,13 +133,15 @@ def db_users(
         completed_process = subprocess.run(
             shlex.split(
                 f'dominode-admin db add-department-user '
-                f'{db_admin_credentials["user"]} '
-                f'{db_admin_credentials["password"]} '
-                f'{db_admin_credentials["db"]} '
-                f'{user} {password} {department} '
+                f'{user} '
+                f'{password} '
+                f'{department} '
                 f'--role={role} '
+                f'--db-admin-username={db_admin_credentials["user"]} '
+                f'--db-admin-password={db_admin_credentials["password"]} '
                 f'--db-host={db_admin_credentials["host"]} '
-                f'--db-port={db_admin_credentials["port"]}'
+                f'--db-port={db_admin_credentials["port"]} '
+                f'--db-name={db_admin_credentials["db"]}'
             ),
             capture_output=True
         )
@@ -258,16 +262,16 @@ def bootstrapped_minio_server(
 ):
     server_alias = 'dominode-pytest'
     command_kwargs = (
-        f'--alias {server_alias} '
-        f'--host localhost '
-        f'--port {minio_server_info["port"]} '
-        f'--protocol http '
+        f'--access-key={minio_server_info["access_key"]} '
+        f'--secret-key={minio_server_info["secret_key"]} '
+        f'--alias={server_alias} '
+        f'--host=localhost '
+        f'--port={minio_server_info["port"]} '
+        f'--protocol=http '
     )
     completed_process = subprocess.run(
         shlex.split(
             f'dominode-admin minio bootstrap {command_kwargs} '
-            f'{minio_server_info["access_key"]} '
-            f'{minio_server_info["secret_key"]}'
         ),
         capture_output=True
     )
@@ -284,8 +288,6 @@ def bootstrapped_minio_server(
             shlex.split(
                 f'dominode-admin minio add-department-user {command_kwargs} '
                 f'--role {role} {access_key} {secret_key} {department_name} '
-                f'{minio_server_info["access_key"]} '
-                f'{minio_server_info["secret_key"]}'
             ),
             capture_output=True
         )

--- a/dominode-bootstrapper/tests/interactive/docker-compose.yml
+++ b/dominode-bootstrapper/tests/interactive/docker-compose.yml
@@ -46,4 +46,4 @@ services:
       MINIO_SECRET_KEY: mypassword
 
   bootstrapper:
-    image: ricardogsilva/dominode-bootstrapper:0.1.0
+    image: kartoza/dominode_bootstrapper:0.1.0

--- a/dominode-bootstrapper/tests/interactive/docker-compose.yml
+++ b/dominode-bootstrapper/tests/interactive/docker-compose.yml
@@ -2,28 +2,12 @@
 #
 # docker-compose up -d
 #
-# docker-compose run \
-#     --name test-bootstrap \
-#     --rm \
-#     bootstrapper \
-#     bootstrap \
-#         --db-host db \
-#         --minio-host minio \
-#         --minio-protocol http \
-#         postgres postgres myuser mypassword
+# docker-compose run --name test-bootstrap --rm bootstrapper bootstrap
 #
 # Alternatively, bootstrap individual components:
 #
-# docker-compose run \
-#     --name test-bootstrap-db \
-#     --rm \
-#     bootstrapper \
-#     db bootstrap postgres postgres postgres --db-host db
-#
-# docker-compose run \
-#     --name test-bootstrap-minio \
-#     --rm bootstrapper \
-#     minio bootstrap --host minio --protocol http myuser mypassword
+# docker-compose run --name test-bootstrap-db --rm bootstrapper db bootstrap
+# docker-compose run --name test-bootstrap-minio --rm bootstrapper minio bootstrap
 #
 # docker-compose down
 
@@ -37,6 +21,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+    - target: 5432
+      published: 5433
 
   minio:
     image: minio/minio
@@ -47,3 +34,17 @@ services:
 
   bootstrapper:
     image: kartoza/dominode_bootstrapper:0.1.0
+    environment:
+      DOMINODE__DB__ADMIN_USERNAME: postgres
+      DOMINODE__DB__ADMIN_PASSWORD: postgres
+      DOMINODE__DB__NAME: postgres
+      DOMINODE__DB__HOST: db
+      DOMINODE__DB__PORT: 5432
+      DOMINODE__MINIO__HOST: minio
+      DOMINODE__MINIO__PORT: 9000
+      DOMINODE__MINIO__PROTOCOL: http
+      DOMINODE__MINIO__ADMIN_ACCESS_KEY: myuser
+      DOMINODE__MINIO__ADMIN_SECRET_KEY: mypassword
+      DOMINODE__DEPARTMENT__PPD__GEOSERVER_PASSWORD: geo_ppd
+      DOMINODE__DEPARTMENT__LSD__GEOSERVER_PASSWORD: geo_lsd
+      DOMINODE__DEPARTMENT__FISH__GEOSERVER_PASSWORD: geo_fish

--- a/dominode-bootstrapper/tests/test_bootstrap_db.py
+++ b/dominode-bootstrapper/tests/test_bootstrap_db.py
@@ -27,7 +27,8 @@ def test_user_can_create_tables_on_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(
+                    f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             transaction.rollback()
 
@@ -101,7 +102,8 @@ def test_user_can_call_setStagingPermissions_on_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(
+                    f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             owner_result = connection.execute(
                 sla.text(
@@ -138,7 +140,8 @@ def test_user_can_insert_features_on_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(
+                    f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -174,7 +177,8 @@ def test_user_can_select_features_on_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(
+                    f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
                 sla.text(
@@ -217,7 +221,8 @@ def test_user_can_delete_features_on_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(
+                    f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -260,7 +265,7 @@ def test_user_can_update_features_on_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -305,7 +310,7 @@ def test_user_can_delete_table_on_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(f'DROP TABLE {table_name}')
             transaction.rollback()
@@ -338,7 +343,7 @@ def test_user_can_select_features_from_any_table_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -393,7 +398,7 @@ def test_user_cannot_call_setStagingPermissions_on_table_created_by_another_user
         transaction = connection.begin()
         try:
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
         finally:
             with creator_engine.connect() as connection:
@@ -424,13 +429,13 @@ def test_same_department_user_can_call_moveTableToDominodeStaging_on_table_creat
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
         with connection.begin() as transaction:
             connection.execute(
-                sla.text(f'SELECT moveTableToDominodeStagingSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToDominodeStagingSchema(\'{table_name}\')')
             )
     new_table_name = table_name.replace(schemaname, 'dominode_staging')
     with creator_engine.connect() as connection:
@@ -461,14 +466,14 @@ def test_user_cannot_call_moveTableToDominodeStagingSchema_on_table_owned_by_ano
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
         transaction = connection.begin()
         try:
             connection.execute(
-                sla.text(f'SELECT moveTableToDominodeStagingSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToDominodeStagingSchema(\'{table_name}\')')
             )
         finally:
             with creator_engine.connect() as connection:
@@ -500,14 +505,14 @@ def test_user_cannot_call_moveTableToPublicSchema_on_table_owned_by_another_depa
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
         transaction = connection.begin()
         try:
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
         finally:
             with creator_engine.connect() as connection:
@@ -539,7 +544,7 @@ def test_same_department_user_can_insert_features_on_table_created_by_another_us
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
@@ -583,7 +588,7 @@ def test_same_department_user_can_delete_features_on_table_created_by_another_us
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -632,7 +637,7 @@ def test_same_department_user_can_update_features_on_table_created_by_another_us
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -683,7 +688,7 @@ def test_same_department_user_can_delete_table_created_by_another_user_on_stagin
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
@@ -711,7 +716,7 @@ def test_user_cannot_create_tables_on_another_department_staging_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             transaction.rollback()
 
@@ -747,7 +752,7 @@ def test_user_cannot_select_features_on_table_from_another_department_staging_sc
                 geom='LINESTRING(-71.160 42.258, -71.160 42.259, -71.161 42.25)'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
@@ -787,7 +792,7 @@ def test_user_cannot_insert_features_on_table_owned_by_another_department(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
@@ -838,7 +843,7 @@ def test_user_cannot_delete_features_on_table_owned_by_another_department(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -891,7 +896,7 @@ def test_user_cannot_update_features_on_table_owned_by_another_department(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -949,7 +954,7 @@ def test_user_cannot_delete_table_owned_by_another_department(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
     with modifier_engine.connect() as connection:
@@ -985,10 +990,10 @@ def test_user_can_call_moveTableToDominodeStagingSchema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToDominodeStagingSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToDominodeStagingSchema(\'{table_name}\')')
             )
             owner_result = connection.execute(
                 sla.text(
@@ -1027,7 +1032,7 @@ def test_user_can_call_moveTableToDominodeStagingSchema_without_calling_setStagi
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToDominodeStagingSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToDominodeStagingSchema(\'{table_name}\')')
             )
             owner_result = connection.execute(
                 sla.text(
@@ -1066,7 +1071,7 @@ def test_editor_user_can_call_moveTableToPublicSchema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToDominodeStagingSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToDominodeStagingSchema(\'{table_name}\')')
             )
             owner_result = connection.execute(
                 sla.text(
@@ -1105,7 +1110,7 @@ def test_regular_user_cannot_call_moveTableToPublicSchema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
             owner_result = connection.execute(
                 sla.text(
@@ -1140,10 +1145,10 @@ def test_editor_user_cannot_insert_features_on_public_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
             public_table_name = table_name.replace(schemaname, 'public')
             insert_query = sla.text(
@@ -1178,7 +1183,7 @@ def test_editor_user_cannot_update_features_on_public_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -1190,7 +1195,7 @@ def test_editor_user_cannot_update_features_on_public_schema(
                 geom='LINESTRING(-71.160 42.258, -71.160 42.259, -71.161 42.25)'
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
             public_table_name = table_name.replace(schemaname, 'public')
             update_query = sla.text(
@@ -1225,7 +1230,7 @@ def test_editor_user_cannot_delete_features_on_public_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -1237,7 +1242,7 @@ def test_editor_user_cannot_delete_features_on_public_schema(
                 geom='LINESTRING(-71.160 42.258, -71.160 42.259, -71.161 42.25)'
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
             public_table_name = table_name.replace(schemaname, 'public')
             update_query = sla.text(
@@ -1271,10 +1276,10 @@ def test_editor_user_can_delete_table_from_public_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
             public_table_name = table_name.replace(schemaname, 'public')
             connection.execute(f'DROP TABLE {public_table_name}')
@@ -1305,10 +1310,10 @@ def test_regular_user_cannot_insert_features_on_table_in_public_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
     public_table_name = table_name.replace(schemaname, 'public')
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
@@ -1357,7 +1362,7 @@ def test_regular_user_cannot_update_features_on_table_in_public_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             insert_query = sla.text(
                 f'INSERT INTO {table_name} (road_name, geom) VALUES (:name, ST_GeomFromText(:geom, 4326))'
@@ -1369,7 +1374,7 @@ def test_regular_user_cannot_update_features_on_table_in_public_schema(
                 geom='LINESTRING(-71.160 42.258, -71.160 42.259, -71.161 42.25)'
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
     public_table_name = table_name.replace(schemaname, 'public')
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
@@ -1418,10 +1423,10 @@ def test_regular_user_cannot_delete_table_in_public_schema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
     public_table_name = table_name.replace(schemaname, 'public')
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
@@ -1470,10 +1475,10 @@ def test_user_can_select_features_in_public_schema(
                 geom='LINESTRING(-71.160 42.258, -71.160 42.259, -71.161 42.25)'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
     public_table_name = table_name.replace(schemaname, 'public')
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
@@ -1519,10 +1524,10 @@ def test_regular_user_cannot_delete_features_from_table_in_public_schema(
                 geom='LINESTRING(-71.160 42.258, -71.160 42.259, -71.161 42.25)'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
     public_table_name = table_name.replace(schemaname, 'public')
     modifier_engine = _connect_to_db(modifier_username, db_admin_credentials, db_users_credentials)
@@ -1569,10 +1574,10 @@ def test_regular_user_can_call_copyTableBackToStagingSchema(
                 f'(id serial, road_name text, geom geometry(LINESTRING, 4326))'
             )
             connection.execute(
-                sla.text(f'SELECT setStagingPermissions(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeSetStagingPermissions(\'{table_name}\')')
             )
             connection.execute(
-                sla.text(f'SELECT moveTableToPublicSchema(\'{table_name}\')')
+                sla.text(f'SELECT DomiNodeMoveTableToPublicSchema(\'{table_name}\')')
             )
     public_table_name = table_name.replace(initial_schemaname, 'public')
     copied_table_name = public_table_name.replace(
@@ -1581,7 +1586,7 @@ def test_regular_user_can_call_copyTableBackToStagingSchema(
     with modifier_engine.connect() as connection:
         connection.execute(
             sla.text(
-                f'SELECT copyTableBackToStagingSchema('
+                f'SELECT DomiNodeCopyTableBackToStagingSchema('
                 f'\'{public_table_name}\', \'{copied_table_name}\')'
             )
         )


### PR DESCRIPTION
This PR adds additional `{department}_geoserver` database users that shall be used to configure GeoServer access to the database.

It also includes a comprehensive refactor of the `dbadmin` module, now making it more reliant on running Python commands instead of simply running a SQL script. With this change, `dbadmin.bootstrap()` is now idempotent.

Finally, this also includes an enhanced facility for passing configuration and secret values to `dominode-admin` command. These may now be specified by one of the following:

- a conf file stored in one of `/etc/dominodedominode-bootstrapper.conf/`, `$HOME/.config/dominode-bootstrapper/config.json` or whatever path is defined by the `DOMINODE_BOOTSTRAPPER_CONFIG_PATH` environment variable
- environment variables of the form `DOMINODE__{conf-section}__{conf-key}={conf-value}` or `DOMINODE__DEPARTMENT__{department-name}__{conf-key}={conf-value}`-

example conf file:

```conf
[db]
admin_username = admin
admin_password = mypassword

[minio]
admin_access_key = mykey
admin_secret_key = mysecret

[ppd-department]
geoserver_password = somepassword
```

corresponding config, specified as env variables:

```
DOMINODE__DB__ADMIN_USERNAME=admin
DOMINODE__DB__ADMIN_PASSWORD=mypassword
DOMINODE__MINIO__ADMIN_ACCESS_KEY=mykey
DOMINODE__MINIO__ADMIN_SECRET_KEY=mysecret
DOMINODE__DEPARTMENT__PPD__GEOSERVER_PASSWORD=somepassword
```



fixes #76