### PR TITLE
88 allow setting multiple db groups

### DIFF
--- a/dominode-bootstrapper/dominode_bootstrapper/dbadmin.py
+++ b/dominode-bootstrapper/dominode_bootstrapper/dbadmin.py
@@ -128,7 +128,7 @@ def bootstrap(
 def add_department_user(
         username: str,
         password: str,
-        department: str,
+        departments: typing.List[str],
         role: typing.Optional[UserRole] = UserRole.REGULAR_DEPARTMENT_USER,
         db_admin_username: typing.Optional[str] = config['db']['admin_username'],
         db_admin_password: typing.Optional[str] = config['db']['admin_password'],
@@ -140,21 +140,11 @@ def add_department_user(
         f'postgresql://{db_admin_username}:{db_admin_password}@'
         f'{db_host}:{db_port}/{db_name or db_admin_username}'
     )
-    sql_role = {
-        UserRole.EDITOR: f'{department}_editor',
-        UserRole.REGULAR_DEPARTMENT_USER: f'{department}_user',
-    }[role]
+    role_suffix = 'editor' if role == UserRole.EDITOR else 'user'
+    parent_roles = [f'{dep}_{role_suffix}' for dep in departments]
     with get_db_connection(db_url) as db_connection:
-        create_user(username, password, db_connection, parent_roles=[sql_role])
-        # create_role(
-        #     username,
-        #     db_connection,
-        #     other_options=(
-        #         f'IN ROLE {sql_role}',
-        #         'LOGIN',
-        #         f'PASSWORD \'{password}\''
-        #     )
-        # )
+        create_user(
+            username, password, db_connection, parent_roles=parent_roles)
 
 
 def create_role(

--- a/dominode-bootstrapper/tests/interactive/docker-compose.yml
+++ b/dominode-bootstrapper/tests/interactive/docker-compose.yml
@@ -46,4 +46,4 @@ services:
       MINIO_SECRET_KEY: mypassword
 
   bootstrapper:
-    image: ricardogsilva/dominode-bootstrapper:0.1.0
+    image: kartoza/dominode_bootstrapper:0.1.0


### PR DESCRIPTION
This PR implements the ability to create DB users that are part of multiple departments. Example usage:

```
poetry run dominode-admin db add-department-user myuser mypassword ppd lsd dowasco --role=editor
```

fixes #88 