### PR TITLE
Add bootstrapper phase for staging setup

### DIFF
--- a/charts/testing/ci/bootstrapper-values.yaml
+++ b/charts/testing/ci/bootstrapper-values.yaml
@@ -1,0 +1,27 @@
+# Section for bootstrapper
+bootstrapper:
+  enabled: true
+  config: |
+    [db]
+    admin_username: {{ .Values.dominode.geonode.global.geodatabaseUsername }}
+    admin_password: {{ .Values.dominode.geonode.global.geodatabasePassword.value }}
+    name: {{ .Values.dominode.geonode.global.geodatabaseName }}
+    host: dominode-geonode-geodatabase
+    port: {{ .Values.dominode.geonode.global.geodatabasePort }}
+
+    [minio]
+    admin_access_key: {{ .Values.minio.global.minio.accessKey }}
+    admin_secret_key: {{ .Values.minio.global.minio.secretKey }}
+    host: minio
+    port: {{ .Values.minio.service.port }}
+    protocol: http
+
+    [geonode]
+    base_url: http://dominode-geonode
+    admin_username: {{ .Values.dominode.geonode.global.adminUser }}
+    admin_password: {{ .Values.dominode.geonode.global.adminPassword.value }}
+
+    [geoserver]
+    base_url: http://dominode-geonode-geoserver/geoserver
+    admin_username: {{ .Values.dominode.geonode.global.geoserverAdminUser }}
+    admin_password: {{ .Values.dominode.geonode.global.geoserverAdminPassword.value }}

--- a/charts/testing/templates/bootstrapper-job.yaml
+++ b/charts/testing/templates/bootstrapper-job.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.bootstrapper.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dominode-bootstrapper
+spec:
+  template:
+    spec:
+      containers:
+      - name: dominode-bootstrapper
+        image: {{ .Values.bootstrapper.image }}
+        args:
+          - bootstrap
+        volumeMounts:
+          - mountPath: /etc/dominode
+            name: bootstrapper-conf
+      volumes:
+        - name: bootstrapper-conf
+          secret:
+            secretName: dominode-bootstrapper-config
+      restartPolicy: OnFailure
+...
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dominode-bootstrapper-config
+  labels:
+    release: {{ .Release.Name }}
+stringData:
+  dominode-bootstrapper.conf: |
+    {{ (tpl .Values.bootstrapper.config $) | nindent 4 }}
+...
+{{- end }}

--- a/charts/testing/values.yaml
+++ b/charts/testing/values.yaml
@@ -155,3 +155,32 @@ dominode:
     debug: "True"
     celeryAsync:
       enabled: true
+
+# Section for bootstrapper
+bootstrapper:
+  enabled: false
+  image: kartoza/dominode_bootstrapper:0.2.0
+  config: |
+    [db]
+    admin_username: {{ .Values.dominode.geonode.global.geodatabaseUsername }}
+    admin_password: {{ .Values.dominode.geonode.global.geodatabasePassword.value }}
+    name: {{ .Values.dominode.geonode.global.geodatabaseName }}
+    host: dominode-geonode-geodatabase
+    port: {{ .Values.dominode.geonode.global.geodatabasePort }}
+
+    [minio]
+    admin_access_key: {{ .Values.minio.global.minio.accessKey }}
+    admin_secret_key: {{ .Values.minio.global.minio.secretKey }}
+    host: minio
+    port: {{ .Values.minio.service.port }}
+    protocol: http
+
+    [geonode]
+    base_url: http://dominode-geonode
+    admin_username: {{ .Values.dominode.geonode.global.adminUser }}
+    admin_password: {{ .Values.dominode.geonode.global.adminPassword.value }}
+
+    [geoserver]
+    base_url: http://dominode-geonode-geoserver/geoserver
+    admin_username: {{ .Values.dominode.geonode.global.geoserverAdminUser }}
+    admin_password: {{ .Values.dominode.geonode.global.geoserverAdminPassword.value }}


### PR DESCRIPTION
@ricardogsilva The PR is complete and runnable, but I have several feedback from using the bootstrapper that might change some files in this PR.

- For config `db` is this for the geospatial store or for the django database?
- Was the geonode and geoserver url supposed to be public url or it can use k8s internal service? (internal route). Did you use it to construct public URL and store it somewhere (like GeoNode thumbnails) or you just need it to access the API?
- Can we use internal route for minio and db connections?
- Can I assume that the bootstrapper is idempotent or do I need to somehow flag the completion?