### PR TITLE
Integrate pygeoapi

### DIFF
--- a/geonode_dominode/dominode_pygeoapi/apps.py
+++ b/geonode_dominode/dominode_pygeoapi/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class DominodePygeoapiConfig(AppConfig):
+    name = 'dominode_pygeoapi'

--- a/geonode_dominode/dominode_pygeoapi/urls.py
+++ b/geonode_dominode/dominode_pygeoapi/urls.py
@@ -7,9 +7,44 @@ from . import views
 
 urlpatterns = [
     path(
-        '/',
+        '',
         views.pygeoapi_root,
         name='pygeoapi-root'
+    ),
+    path(
+        'openapi/',
+        views.pygeoapi_openapi_endpoint,
+        name='pygeoapi-openapi'
+    ),
+    path(
+        'conformance/',
+        views.pygeoapi_conformance_endpoint,
+        name='pygeoapi-conformance'
+    ),
+    path(
+        'collections/',
+        views.pygeoapi_collections_endpoint,
+        name='pygeoapi-collection-list'
+    ),
+    path(
+        'collections/<str:name>/',
+        views.pygeoapi_collections_endpoint,
+        name='pygeoapi-collection-detail'
+    ),
+    path(
+        'collections/<str:name>/queryables/',
+        views.pygeoapi_collection_queryables,
+        name='pygeoapi-collection-queryable-list'
+    ),
+    path(
+        'collections/<str:collection_id>/items/',
+        views.get_pygeoapi_dataset_list,
+        name='pygeoapi-collection-item-list'
+    ),
+    path(
+        'collections/<str:collection_id>/items/<str:item_id>/',
+        views.get_pygeoapi_dataset_detail,
+        name='pygeoapi-collection-item-detail'
     ),
     path(
         'stac/',
@@ -17,8 +52,18 @@ urlpatterns = [
         name='pygeoapi-stac-catalog-root'
     ),
     path(
-        'stac/<str:path>',
-        views.stac_catalog_path,
+        'stac/<path:path>',
+        views.stac_catalog_path_endpoint,
         name='pygeoapi-stac-catalog-path'
+    ),
+    path(
+        'processes/',
+        views.get_pygeoapi_processes,
+        name='pygeoapi-process-list'
+    ),
+    path(
+        'processes/<str:name>',
+        views.get_pygeoapi_processes,
+        name='pygeoapi-process-detail'
     ),
 ]

--- a/geonode_dominode/dominode_pygeoapi/urls.py
+++ b/geonode_dominode/dominode_pygeoapi/urls.py
@@ -1,0 +1,24 @@
+from django.urls import (
+    include,
+    path,
+)
+
+from . import views
+
+urlpatterns = [
+    path(
+        '/',
+        views.pygeoapi_root,
+        name='pygeoapi-root'
+    ),
+    path(
+        'stac/',
+        views.stac_catalog_root,
+        name='pygeoapi-stac-catalog-root'
+    ),
+    path(
+        'stac/<str:path>',
+        views.stac_catalog_path,
+        name='pygeoapi-stac-catalog-path'
+    ),
+]

--- a/geonode_dominode/dominode_pygeoapi/views.py
+++ b/geonode_dominode/dominode_pygeoapi/views.py
@@ -1,0 +1,51 @@
+import typing
+
+from django.conf import settings
+from django.http import (
+    HttpRequest,
+    HttpResponse
+)
+from pygeoapi.api import API
+
+# TODO: test these views
+# TODO: add authentication
+# TODO: add authorization
+
+def pygeoapi_root(request: HttpRequest):
+    pygeoapi_response = _get_pygeoapi_response(request, 'root')
+    return _convert_pygeoapi_response_to_django_response(pygeoapi_response)
+
+
+def stac_catalog_root(request: HttpRequest):
+    pygeoapi_response = _get_pygeoapi_response(request, 'get_stac_root')
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def stac_catalog_path_endpoint(
+        request: HttpRequest, path: typing.Optional[str] = None):
+    pygeoapi_response = _get_pygeoapi_response(
+        request, 'get_stac_path', path=path)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def _get_pygeoapi_response(
+        request: HttpRequest,
+        api_method_name: str,
+        **kwargs
+) -> typing.Tuple[typing.Dict, int, str]:
+    """Use pygeoapi to process the input request"""
+    pygeoapi_api = API(settings.PYGEOAPI_CONFIG)
+    api_method = getattr(pygeoapi_api, api_method_name)
+    return api_method(request.headers, request.get, **kwargs)
+
+
+def _convert_pygeoapi_response_to_django_response(
+        pygeoapi_headers: typing.Mapping,
+        pygeoapi_status_code: int,
+        pygeoapi_content: str,
+) -> HttpResponse:
+    """Convert pygeoapi response to a django response"""
+    response = HttpResponse(pygeoapi_content, status=pygeoapi_status_code)
+    for key, value in pygeoapi_headers.items():
+        response[key] = value
+    return response

--- a/geonode_dominode/dominode_pygeoapi/views.py
+++ b/geonode_dominode/dominode_pygeoapi/views.py
@@ -1,3 +1,4 @@
+"""Integration of pygeoapi into DomiNode"""
 import typing
 
 from django.conf import settings
@@ -6,37 +7,98 @@ from django.http import (
     HttpResponse
 )
 from pygeoapi.api import API
+from pygeoapi.openapi import get_oas
 
 # TODO: test these views
 # TODO: add authentication
 # TODO: add authorization
 
-def pygeoapi_root(request: HttpRequest):
+def pygeoapi_root(request: HttpRequest) -> HttpResponse:
     pygeoapi_response = _get_pygeoapi_response(request, 'root')
-    return _convert_pygeoapi_response_to_django_response(pygeoapi_response)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
 
 
-def stac_catalog_root(request: HttpRequest):
+def pygeoapi_openapi_endpoint(request: HttpRequest) -> HttpResponse:
+    openapi_config = get_oas(settings.PYGEOAPI_CONFIG)
+    pygeoapi_response = _get_pygeoapi_response(
+        request, 'openapi', openapi_config)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def pygeoapi_conformance_endpoint(request: HttpRequest) -> HttpResponse:
+    pygeoapi_response = _get_pygeoapi_response(request, 'conformance')
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def pygeoapi_collections_endpoint(
+        request: HttpRequest,
+        name: typing.Optional[str] = None,
+) -> HttpResponse:
+    pygeoapi_response = _get_pygeoapi_response(
+        request, 'describe_collections', name)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def pygeoapi_collection_queryables(
+        request: HttpRequest,
+        name: typing.Optional[str] = None,
+) -> HttpResponse:
+    pygeoapi_response = _get_pygeoapi_response(
+        request, 'get_collection_queryables', name)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def get_pygeoapi_dataset_list(
+        request: HttpRequest,
+        collection_id: str
+) -> HttpResponse:
+    pygeoapi_response = _get_pygeoapi_response(
+        request, 'get_collection_items', collection_id)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def get_pygeoapi_dataset_detail(
+        request: HttpRequest,
+        collection_id: str,
+        item_id: str,
+) -> HttpResponse:
+    pygeoapi_response = _get_pygeoapi_response(
+        request, 'get_collection_item', collection_id, item_id)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def stac_catalog_root(request: HttpRequest) -> HttpResponse:
     pygeoapi_response = _get_pygeoapi_response(request, 'get_stac_root')
     return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
 
 
 def stac_catalog_path_endpoint(
-        request: HttpRequest, path: typing.Optional[str] = None):
+        request: HttpRequest,
+        path: str
+) -> HttpResponse:
+    pygeoapi_response = _get_pygeoapi_response(request, 'get_stac_path', path)
+    return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
+
+
+def get_pygeoapi_processes(
+        request: HttpRequest,
+        name: typing.Optional[str] = None
+) -> HttpResponse:
     pygeoapi_response = _get_pygeoapi_response(
-        request, 'get_stac_path', path=path)
+        request, 'describe_processes', name)
     return _convert_pygeoapi_response_to_django_response(*pygeoapi_response)
 
 
 def _get_pygeoapi_response(
         request: HttpRequest,
         api_method_name: str,
+        *args,
         **kwargs
 ) -> typing.Tuple[typing.Dict, int, str]:
     """Use pygeoapi to process the input request"""
     pygeoapi_api = API(settings.PYGEOAPI_CONFIG)
     api_method = getattr(pygeoapi_api, api_method_name)
-    return api_method(request.headers, request.get, **kwargs)
+    return api_method(request.headers, request.GET, *args, **kwargs)
 
 
 def _convert_pygeoapi_response_to_django_response(

--- a/geonode_dominode/geonode_dominode/settings.py
+++ b/geonode_dominode/geonode_dominode/settings.py
@@ -167,6 +167,10 @@ LOGGING = {
             "handlers": ["console"], "level": "DEBUG", },
         "geonode_logstash.logstash": {
             "handlers": ["console"], "level": "DEBUG", },
+        "pygeoapi": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+        },
     },
 }
 
@@ -208,11 +212,11 @@ CELERY_TASK_DEFAULT_ROUTING_KEY = 'default'
 
 PYGEOAPI_CONFIG = {
     'server': {
-        'bind': {
-            'host': '',
-            'port': 5000,
-        },
-        'url': '',
+        # 'bind': {
+        #     'host': '0.0.0.0',
+        #     'port': 5000,
+        # },
+        'url': 'http://dominode.test/dominode-pygeoapi/',
         'mimetype': '',
         'encoding': '',
         'language': '',
@@ -226,14 +230,15 @@ PYGEOAPI_CONFIG = {
         'ogc_schemas_location': '',
     },
     'logging': {
-        'level': 'ERROR',
-        'logfile': None,
+        'level': LOGGING['loggers']['pygeoapi']['level'],
     },
     'metadata': {
         'identification': {
-            'title': '',
-            'description': '',
-            'keywords': [],
+            'title': 'DomiNode pygeoapi',
+            'description': 'DomiNode\'s pygeoapi integration endpoints' ,
+            'keywords': [
+                'stac',
+            ],
             'keywords_type': 'theme',
             'terms_of_service': '',
             'url': '',
@@ -243,11 +248,11 @@ PYGEOAPI_CONFIG = {
             'url': '',
         },
         'provider': {
-            'name': '',
-            'url': '',
+            'name': 'Government of the Commonwealth of Dominica',
+            'url': 'https://dominica.gov.dm',
         },
         'contact': {
-            'name': '',
+            'name': 'Charles Louis',
             'position': '',
             'address': '',
             'city': '',
@@ -272,20 +277,24 @@ PYGEOAPI_CONFIG = {
             'context': {},
             'links': {},
             'extents': {
-                'spatial': {},
-                'temporal': {},
+                'spatial': {
+                    'bbox': [-180, -90, 180, 90],
+                    'crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                'temporal': {
+                    'begin': '2019-01-01T00:00:00Z',
+                    'end': '2029-01-01T00:00:00Z',
+                },
             },
-            'providers': [
-                {
-                    'type': 'stac',
-                    'default': True,
-                    'name': 'FileSystem',
-                    'data': '/data',
-                    'file_types': [
-                        '.tif',
-                    ]
-                }
-            ]
+            'provider': {
+                'type': 'stac',
+                'default': True,
+                'name': 'FileSystem',
+                'data': '/data',
+                'file_types': [
+                    '.tif',
+                ]
+            }
         }
     },
 }

--- a/geonode_dominode/geonode_dominode/settings.py
+++ b/geonode_dominode/geonode_dominode/settings.py
@@ -74,6 +74,7 @@ WSGI_APPLICATION = "{}.wsgi.application".format(PROJECT_NAME)
 LANGUAGE_CODE = os.getenv('LANGUAGE_CODE', "en")
 
 INSTALLED_APPS += (
+    'dominode_pygeoapi.apps.DominodePygeoapiConfig',
     'dominode_validation.apps.DominodeValidationConfig',
     'geonode_dominode.apps.AppConfig',
     'rest_framework',
@@ -204,3 +205,87 @@ CELERY_TASK_QUEUES += (
 
 CELERY_TASK_DEFAULT_QUEUE = 'default'
 CELERY_TASK_DEFAULT_ROUTING_KEY = 'default'
+
+PYGEOAPI_CONFIG = {
+    'server': {
+        'bind': {
+            'host': '',
+            'port': 5000,
+        },
+        'url': '',
+        'mimetype': '',
+        'encoding': '',
+        'language': '',
+        'cors': False,
+        'pretty_print': True,
+        'limit': 10,
+        'map': {
+            'url': '',
+            'attribution': '',
+        },
+        'ogc_schemas_location': '',
+    },
+    'logging': {
+        'level': 'ERROR',
+        'logfile': None,
+    },
+    'metadata': {
+        'identification': {
+            'title': '',
+            'description': '',
+            'keywords': [],
+            'keywords_type': 'theme',
+            'terms_of_service': '',
+            'url': '',
+        },
+        'license': {
+            'name': '',
+            'url': '',
+        },
+        'provider': {
+            'name': '',
+            'url': '',
+        },
+        'contact': {
+            'name': '',
+            'position': '',
+            'address': '',
+            'city': '',
+            'stateorprovince': '',
+            'postalcode': '',
+            'country': '',
+            'phone': '',
+            'fax': '',
+            'email': '',
+            'url': '',
+            'hours': '',
+            'instructions': '',
+            'role': 'pointOfContact',
+        },
+    },
+    'resources': {
+        'internal-rasters': {
+            'type': 'stac-collection',
+            'title': 'Internal DomiNode raster datasets',
+            'description': '',
+            'keywords': [],
+            'context': {},
+            'links': {},
+            'extents': {
+                'spatial': {},
+                'temporal': {},
+            },
+            'providers': [
+                {
+                    'type': 'stac',
+                    'default': True,
+                    'name': 'FileSystem',
+                    'data': '/data',
+                    'file_types': [
+                        '.tif',
+                    ]
+                }
+            ]
+        }
+    },
+}

--- a/geonode_dominode/geonode_dominode/urls.py
+++ b/geonode_dominode/geonode_dominode/urls.py
@@ -9,6 +9,7 @@ from geonode.urls import urlpatterns
 from geonode.monitoring import register_url_event
 
 from dominode_validation import urls as dominode_validation_urls
+from dominode_pygeoapi import urls as dominode_pygeoapi_urls
 
 from .views import (
     GroupDetailView,
@@ -31,6 +32,7 @@ urlpatterns = [
         name='sync_geoserver'
     ),
     path('dominode-validation/', include(dominode_validation_urls)),
+    path('dominode-pygeoapi/', include(dominode_pygeoapi_urls)),
     url(r'^layers/upload$', RedirectView.as_view(url='/')),
     url(r'^layers/(?P<layername>[^/]*)/replace$',
         RedirectView.as_view(url='/')),

--- a/geonode_dominode/requirements.txt
+++ b/geonode_dominode/requirements.txt
@@ -3,4 +3,4 @@
 djangorestframework~=3.11
 django-filter~=2.3
 django-json-widget~=1.0
-
+pygeoapi==0.8.0


### PR DESCRIPTION
This PR adds a new `dominode-pygeoapi` django app to integrate [pygeoapi] into DomiNode. The main idea with this is to use pygeoapi's [STAC] support in order to have a STAC server that would be able to serve DomiNode raster datasets.

We would then use this STAC server to let privileged users access raster datasets directly from QGIS using the [STAC Browser plugin].

The current PR is a very early draft of what the STAC server would look like. Unfortunately, while implementing this I realized that pygeoapi's STAC implementation is still incomplete. Check here for more details:

-  https://github.com/kbgg/qgis-stac-browser/issues/77#issuecomment-705248333
-  https://github.com/geopython/pygeoapi/issues/221#issuecomment-705249754

This means that it is currently not possible to use the QGIS STAC browser plugin with a server that uses pygeoapi.

This situation may change in the near future, so I'm leaving this PR open (in draft form) for reference in order to revisit it later




[pygeoapi]: https://pygeoapi.io/
[STAC]: https://stacspec.org/
[STAC Browser Plugin]: https://plugins.qgis.org/plugins/stac_browser/