### PR TITLE
Add a link to geoserver to user menu for relevant users

### DIFF
--- a/geonode_dominode/geonode_dominode/constants.py
+++ b/geonode_dominode/geonode_dominode/constants.py
@@ -1,1 +1,2 @@
 GEOSERVER_SYNC_PERM_CODE = 'can_sync_geoserver'
+GEOSERVER_SYNC_CATEGORY_NAME = 'dominode-editor'

--- a/geonode_dominode/geonode_dominode/context_processors.py
+++ b/geonode_dominode/geonode_dominode/context_processors.py
@@ -1,0 +1,22 @@
+"""Extra context processors for DomiNode
+
+These add stuff to the context that is available for all templates
+
+"""
+
+import typing
+
+from django.http import HttpRequest
+
+from .constants import GEOSERVER_SYNC_CATEGORY_NAME
+
+
+def user_is_geoserver_editor(request: HttpRequest) -> typing.Dict:
+    if request.user.is_authenticated:
+        has_editor_category = request.user.groupmember_set.filter(
+            group__categories__name=GEOSERVER_SYNC_CATEGORY_NAME).exists()
+    else:
+        has_editor_category = False
+    return {
+        'user_is_geoserver_editor': has_editor_category
+    }

--- a/geonode_dominode/geonode_dominode/settings.py
+++ b/geonode_dominode/geonode_dominode/settings.py
@@ -119,6 +119,8 @@ loaders = TEMPLATES[0]['OPTIONS'].get('loaders') or ['django.template.loaders.fi
 # loaders.insert(0, 'apptemplates.Loader')
 TEMPLATES[0]['OPTIONS']['loaders'] = loaders
 TEMPLATES[0].pop('APP_DIRS', None)
+TEMPLATES[0]['OPTIONS']['context_processors'].append(
+    'geonode_dominode.context_processors.user_is_geoserver_editor')
 
 LOGGING = {
     'version': 1,

--- a/geonode_dominode/geonode_dominode/signals.py
+++ b/geonode_dominode/geonode_dominode/signals.py
@@ -8,7 +8,10 @@ from django.dispatch import receiver
 from geonode.groups.models import GroupProfile
 from guardian.shortcuts import assign_perm
 
-from .constants import GEOSERVER_SYNC_PERM_CODE
+from .constants import (
+    GEOSERVER_SYNC_CATEGORY_NAME,
+    GEOSERVER_SYNC_PERM_CODE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +30,9 @@ def check_assign_geoserver_sync_permission(
     """Assign GeoServer sync perm when a suitable Group instance is created."""
     if action == 'post_add':
         existing_categories = [cat.name for cat in instance.categories.all()]
-        if instance.categories.filter(name='dominode-editor').exists():
+        has_editor_category = instance.categories.filter(
+            name=GEOSERVER_SYNC_CATEGORY_NAME).exists()
+        if has_editor_category:
             group = instance.group
             logger.debug(
                 f'Assigning geoserver sync permission to group {group}...')

--- a/geonode_dominode/geonode_dominode/templates/site_base.html
+++ b/geonode_dominode/geonode_dominode/templates/site_base.html
@@ -97,15 +97,17 @@
                             </li>
                             {% endif %}
                             <li><a href="{% url "messages_inbox" %}">{% trans "Inbox" %}</a></li>
-                            {% if user.is_superuser or user.is_staff %}
+                            {% if user.is_superuser or user.is_staff or user_is_geoserver_editor%}
                                 <li role="separator" class="divider"></li>
-                                <li><a href="{% url "admin:index" %}">{% trans "Admin" %}</a></li>
-                                {% if 'geonode.geoserver' in INSTALLED_APPS %}
-                                <li><a href="{{ OGC_SERVER.default.WEB_UI_LOCATION }}">GeoServer</a></li>
+                                {% if user.is_superuser or user.is_staff %}
+                                    <li><a href="{% url "admin:index" %}">{% trans "Admin" %}</a></li>
+                                {% endif %}
+                                {% if 'geonode.geoserver' in INSTALLED_APPS and user.is_superuser or user.is_staff or user_is_geoserver_editor %}
+                                    <li><a href="{{ OGC_SERVER.default.WEB_UI_LOCATION }}">GeoServer</a></li>
                                 {% endif %}
                                 {% if USE_MONITORING %}
-                                <li role="separator" class="divider"></li>
-                                <li><a href="{% url "monitoring:index" %}">{% trans "Monitoring & Analytics" %}</a></li>
+                                    <li role="separator" class="divider"></li>
+                                    <li><a href="{% url "monitoring:index" %}">{% trans "Monitoring & Analytics" %}</a></li>
                                 {% endif %}
                             {% endif %}
                             <li role="separator" class="divider"></li>


### PR DESCRIPTION
This PR adds a link to GeoServer in the user menu, for relevant users.

Implementation consists in adding a new global context processor that verifies if the current user is member of a group profile that has the `dominode-editor` category. If so then a link to GeoServer is added to the user menu.

![Screenshot from 2020-10-08 22-54-32](https://user-images.githubusercontent.com/732010/95517630-453a9900-09b9-11eb-8680-9fdc2dbf75b9.png)


fixes #105 